### PR TITLE
Fixed wrong zip file name

### DIFF
--- a/KAV_Simulation/displays_platformio.ini
+++ b/KAV_Simulation/displays_platformio.ini
@@ -15,7 +15,7 @@ build_src_filter =
 lib_deps = 															; You can add additional libraries if required
 custom_core_firmware_version = 2.5.1								; define the version from the core firmware files your build should base on
 custom_device_folder = KAV_Simulation								; path to your Custom Device Sources
-custom_community_project = kavSimulation							; Should match "Project" from section "Community" within the board.json file, it's the name of the ZIP file
+custom_community_project = kavSimulations							; Should match "Project" from section "Community" within the board.json file, it's the name of the ZIP file
 
 
 ; Build settings for the Arduino Mega with Custom Firmware for Kav's FCU and EFIS

--- a/KAV_Simulation/displays_platformio.ini
+++ b/KAV_Simulation/displays_platformio.ini
@@ -15,7 +15,7 @@ build_src_filter =
 lib_deps = 															; You can add additional libraries if required
 custom_core_firmware_version = 2.5.1								; define the version from the core firmware files your build should base on
 custom_device_folder = KAV_Simulation								; path to your Custom Device Sources
-custom_community_project = KAV_Simulation							; Should match "Project" from section "Community" within the board.json file, it's the name of the ZIP file
+custom_community_project = kavSimulation							; Should match "Project" from section "Community" within the board.json file, it's the name of the ZIP file
 
 
 ; Build settings for the Arduino Mega with Custom Firmware for Kav's FCU and EFIS


### PR DESCRIPTION
## Description of changes

The zip file and the folder inside has the wrong file name, it must be `kavSimulation` as before and not `KAV Simulation`.