### PR TITLE
Fix overflow of altitude value

### DIFF
--- a/KAV_Simulation/KAV_A3XX_FCU_LCD.cpp
+++ b/KAV_Simulation/KAV_A3XX_FCU_LCD.cpp
@@ -238,7 +238,7 @@ void KAV_A3XX_FCU_LCD::showAltitudeValue(uint32_t value)
 {
     char bufferDigits[10] = {0};
 
-    snprintf(bufferDigits, 10, "%05d", (int)value);
+    snprintf(bufferDigits, 10, "%05u", (uint16_t)value);
     showAltitudeValue(bufferDigits);
 }
 


### PR DESCRIPTION
## Description of changes

Altitude >= 32768 will overflow and negative values are shown.
For AVR's snprintf() is limited to `int` or `uint`. When setting up the new code structure I was using int32_t but got a warning that snprintf() is limited to `int`. So I casted the value to `int` without thinking about that values >= 32768 are valid.

snprintf() is now used with `uint16_t` which can be handled for AVR's. Max. altitude will not exceed 65535. 

