### PR TITLE
Function name cleanup

### DIFF
--- a/KAV_Simulation/Community/boards/kav_mega.board.json
+++ b/KAV_Simulation/Community/boards/kav_mega.board.json
@@ -37,7 +37,7 @@
     "DelayAfterFirmwareUpdate": 0,
     "FirmwareBaseName": "kav_mega",
     "FirmwareExtension": "hex",
-    "LatestFirmwareVersion": "2.5.3",
+    "LatestFirmwareVersion": "2.5.4",
     "FriendlyName": "Kav Mega",
     "MobiFlightType": "Kav Mega",
     "ResetFirmwareFile": "reset.arduino_mega_1_0_2.hex",

--- a/KAV_Simulation/Community/boards/kav_pico.board.json
+++ b/KAV_Simulation/Community/boards/kav_pico.board.json
@@ -20,7 +20,7 @@
     "FirmwareBaseName": "kav_raspberrypico",
     "FirmwareExtension": "uf2",
     "FriendlyName": "Kav RaspiPico",
-    "LatestFirmwareVersion": "2.5.3",
+    "LatestFirmwareVersion": "2.5.4",
     "MobiFlightType": "Kav RaspiPico",
     "ResetFirmwareFile": "reset.raspberry_pico_flash_nuke.uf2",
     "CustomDeviceTypes": [

--- a/KAV_Simulation/Community/config/KavSim Glareshield Board Config v1-1-0.mfmc
+++ b/KAV_Simulation/Community/config/KavSim Glareshield Board Config v1-1-0.mfmc
@@ -6,22 +6,22 @@
   <CustomDevice Name="FCU LCD" CustomType="KAV_FCU" Pins="" Config="">
     <ConfiguredPins>
       <string>8</string>
-      <string>12</string>
       <string>11</string>
+      <string>12</string>
     </ConfiguredPins>
   </CustomDevice>
   <CustomDevice Name="EFIS L" CustomType="KAV_EFIS" Pins="" Config="">
     <ConfiguredPins>
       <string>34</string>
-      <string>32</string>
       <string>33</string>
+      <string>32</string>
     </ConfiguredPins>
   </CustomDevice>
   <CustomDevice Name="EFIS R" CustomType="KAV_EFIS" Pins="" Config="">
     <ConfiguredPins>
       <string>37</string>
-      <string>35</string>
       <string>36</string>
+      <string>35</string>
     </ConfiguredPins>
   </CustomDevice>
 </Config>

--- a/KAV_Simulation/Community/config/KavSim Overhead Board Config v1-1-0.mfmc
+++ b/KAV_Simulation/Community/config/KavSim Overhead Board Config v1-1-0.mfmc
@@ -3,32 +3,32 @@
   <ModuleType>Kav Mega</ModuleType>
   <ModuleName>Kav Overhead</ModuleName>
   <PowerSavingTime>600</PowerSavingTime>
-  <CustomDevice Name="BAT 1" CustomType="KAV_BATTERY" Pins="34|32|33" Config="">
+  <CustomDevice Name="BAT 1" CustomType="KAV_BATTERY" Pins="11|13|12" Config="">
     <ConfiguredPins>
       <string>11</string>
-      <string>13</string>
       <string>12</string>
+      <string>13</string>
     </ConfiguredPins>
   </CustomDevice>
-  <CustomDevice Name="BAT 2" CustomType="KAV_BATTERY" Pins="37|35|36" Config="">
+  <CustomDevice Name="BAT 2" CustomType="KAV_BATTERY" Pins="8|10|9" Config="">
     <ConfiguredPins>
       <string>8</string>
-      <string>10</string>
       <string>9</string>
+      <string>10</string>
     </ConfiguredPins>
   </CustomDevice>
-  <CustomDevice Name="ACTIVE" CustomType="KAV_RAD_TCAS" Pins="25|23|24" Config="">
+  <CustomDevice Name="ACTIVE" CustomType="KAV_RAD_TCAS" Pins="5|7|6" Config="">
     <ConfiguredPins>
       <string>5</string>
-      <string>7</string>
       <string>6</string>
+      <string>7</string>
     </ConfiguredPins>
   </CustomDevice>
-  <CustomDevice Name="STBY-CRS" CustomType="KAV_RAD_TCAS" Pins="28|30|29" Config="">
+  <CustomDevice Name="STBY-CRS" CustomType="KAV_RAD_TCAS" Pins="2|4|3" Config="">
     <ConfiguredPins>
       <string>2</string>
-      <string>4</string>
       <string>3</string>
+      <string>4</string>
     </ConfiguredPins>
   </CustomDevice>
 </Config>

--- a/KAV_Simulation/Community/config/KavSim Pedestal Board Config v1-1-0.mfmc
+++ b/KAV_Simulation/Community/config/KavSim Pedestal Board Config v1-1-0.mfmc
@@ -6,43 +6,43 @@
   <CustomDevice Name="RMP L ACTIVE" CustomType="KAV_RAD_TCAS" Pins="5|7|6" Config="">
     <ConfiguredPins>
       <string>11</string>
-      <string>13</string>
       <string>12</string>
+      <string>13</string>
     </ConfiguredPins>
   </CustomDevice>
   <CustomDevice Name="RMP L STBY-CRS" CustomType="KAV_RAD_TCAS" Pins="2|4|3" Config="">
     <ConfiguredPins>
       <string>8</string>
-      <string>10</string>
       <string>9</string>
+      <string>10</string>
     </ConfiguredPins>
   </CustomDevice>
   <CustomDevice Name="RMP R ACTIVE" CustomType="KAV_RAD_TCAS" Pins="16|14|15" Config="">
     <ConfiguredPins>
       <string>5</string>
-      <string>7</string>
       <string>6</string>
+      <string>7</string>
     </ConfiguredPins>
   </CustomDevice>
   <CustomDevice Name="RMP R STBY-CRS" CustomType="KAV_RAD_TCAS" Pins="19|17|18" Config="">
     <ConfiguredPins>
       <string>2</string>
-      <string>4</string>
       <string>3</string>
+      <string>4</string>
     </ConfiguredPins>
   </CustomDevice>
   <CustomDevice Name="TCAS" CustomType="KAV_RAD_TCAS" Pins="13|11|12" Config="">
     <ConfiguredPins>
       <string>42</string>
-      <string>44</string>
       <string>43</string>
+      <string>44</string>
     </ConfiguredPins>
   </CustomDevice>
   <CustomDevice Name="RUDDER TRIM" CustomType="KAV_RUDDER" Pins="24|22|23" Config="">
     <ConfiguredPins>
       <string>32</string>
-      <string>34</string>
       <string>33</string>
+      <string>34</string>
     </ConfiguredPins>
   </CustomDevice>
 </Config>

--- a/KAV_Simulation/Community/devices/kav_efis.device.json
+++ b/KAV_Simulation/Community/devices/kav_efis.device.json
@@ -48,7 +48,7 @@
     },
     {
       "id": 5,
-      "label": "Show Value",
+      "label": "(v2.5.4+) Show Value (STRING)",
       "description": "$ will be displayed"
     }
   ]

--- a/KAV_Simulation/Community/devices/kav_efis.device.json
+++ b/KAV_Simulation/Community/devices/kav_efis.device.json
@@ -5,7 +5,7 @@
     "Type": "KAV_EFIS",
     "Author": "Jak Kav",
     "URL": "https://github.com/MobiFlight/MobiFlight-CustomDevices/tree/main/KAV_Simulation/EFIS_FCU",
-    "Version": "1.0.0"
+    "Version": "1.5.0"
   },
   "Config": {
     "Pins": [

--- a/KAV_Simulation/Community/devices/kav_fcu.device.json
+++ b/KAV_Simulation/Community/devices/kav_fcu.device.json
@@ -18,32 +18,32 @@
   "MessageTypes": [
     {
       "id": 0,
-      "label": "Show Speed Value",
+      "label": "Show Speed Value (LEGACY)",
       "description": "$ will be displayed as Speed value"
     },
     {
       "id": 1,
-      "label": "Show Mach Value",
+      "label": "Show Mach Value (LEGACY)",
       "description": "$ will be displayed as Mach value"
     },
     {
       "id": 2,
-      "label": "Show Heading Value",
+      "label": "Show Heading Value (LEGACY)",
       "description": "$ will be displayed as Heading value"
     },
     {
       "id": 3,
-      "label": "Show Altitude",
+      "label": "Show Altitude (LEGACY)",
       "description": "$ will be displayed as Altitude"
     },
     {
       "id": 4,
-      "label": "Show Vertical",
+      "label": "Show Vertical (LEGACY)",
       "description": "$ will be displayed as Vertical"
     },
     {
       "id": 5,
-      "label": "Show FPA",
+      "label": "Show FPA (LEGACY)",
       "description": "$ will be displayed as FPA"
     },
     {
@@ -108,27 +108,27 @@
     },
     {
       "id": 18,
-      "label": "Show Speed/Mach/Dash Value",
-      "description": "$ will be displayed as Speed value, neg. values show dashes"
+      "label": "(v2.5.3+) Show Speed/Mach (STRING)",
+      "description": "$ will be displayed as Speed value. Negative values show dashes"
     },
     {
       "id": 19,
-      "label": "Show Heading/Dash Value",
-      "description": "$ will be displayed as Heading value, neg. values show dashes"
+      "label": "(v2.5.3+) Show Heading (STRING)",
+      "description": "$ will be displayed as Heading value. Negative values show dashes"
     },
     {
       "id": 20,
-      "label": "Show Altitude as String",
+      "label": "(v2.5.3+) Show Altitude (STRING)",
       "description": "$ will be displayed as Altitude"
     },
     {
       "id": 21,
-      "label": "Show Vertical/FPA/Dash",
-      "description": "$ will be displayed as Vertical/FPA/Dash"
+      "label": "(v2.5.3+) Show Vertical/FPA (STRING)",
+      "description": "$ will be displayed as Vertical/FPA"
     },
     {
       "id": 22,
-      "label": "Toggle Speed/Mach mode",
+      "label": "(v2.5.3+) Toggle Speed/Mach mode",
       "description": "$ = 1 will display Mach labels, $ = 2 will display Speed labels"
     }
   ]

--- a/KAV_Simulation/Community/devices/kav_fcu.device.json
+++ b/KAV_Simulation/Community/devices/kav_fcu.device.json
@@ -5,7 +5,7 @@
     "Type": "KAV_FCU",
     "Author": "Jak Kav",
     "URL": "https://github.com/MobiFlight/MobiFlight-CustomDevices/tree/main/KAV_Simulation/EFIS_FCU",
-    "Version": "1.0.1"
+    "Version": "1.5.0"
   },
   "Config": {
     "Pins": [

--- a/KAV_Simulation/Community/profiles/msfs2020/FlyByWire A320/KavSim FBWA320 All-In-One Config V2.mcc
+++ b/KAV_Simulation/Community/profiles/msfs2020/FlyByWire A320/KavSim FBWA320 All-In-One Config V2.mcc
@@ -26,7 +26,7 @@
           <comparison active="True" value="0" operand="&lt;" ifValue="'---'" elseValue="$" />
           <padding active="True" direction="Left" length="3" character="0" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Glareshield/ SN-894-EA3" trigger="normal" customType="" customName="FCU LCD" messageType="18" value="$" />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="18" value="$" />
         <preconditions>
           <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
           <precondition type="config" active="true" ref="97f70f49-f7c5-4c92-af0a-a88bcdab7ecc" operand="=" value="1" logic="and" />
@@ -45,7 +45,7 @@
           <comparison active="True" value="0" operand="&lt;" ifValue="'---'" elseValue="$" />
           <padding active="True" direction="Right" length="4" character="0" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Glareshield/ SN-894-EA3" trigger="normal" customType="" customName="FCU LCD" messageType="18" value="$" />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="18" value="$" />
         <preconditions>
           <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
           <precondition type="config" active="true" ref="97f70f49-f7c5-4c92-af0a-a88bcdab7ecc" operand="=" value="0" logic="and" />
@@ -60,7 +60,7 @@
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_FCU_SPD_MANAGED_DOT)" UUID="6bbe5ddf-c3f9-4f08-8f29-e5d70d88a42a" />
         <test type="Float" value="1" />
         <modifiers />
-        <display type="CustomDevice" serial="Kav Glareshield/ SN-894-EA3" trigger="normal" customType="" customName="FCU LCD" messageType="10" value="$" />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="10" value="$" />
         <preconditions>
           <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
         </preconditions>
@@ -76,7 +76,7 @@
         <modifiers>
           <comparison active="True" value="1" operand="=" ifValue="0" elseValue="1" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Glareshield/ SN-894-EA3" trigger="normal" customType="" customName="FCU LCD" messageType="14" value="$" />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="14" value="$" />
         <preconditions>
           <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
         </preconditions>
@@ -90,7 +90,7 @@
         <source type="SimConnect" VarType="CODE" Value="(A:AUTOPILOT MANAGED SPEED IN MACH,Bool)" UUID="1a2d4936-4073-410f-8081-bf186601a2a2" />
         <test type="Float" value="1" />
         <modifiers />
-        <display type="CustomDevice" serial="Kav Glareshield/ SN-894-EA3" trigger="normal" customType="" customName="FCU LCD" messageType="15" value="$" />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="15" value="$" />
         <preconditions>
           <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
         </preconditions>
@@ -121,7 +121,7 @@
           <comparison active="True" value="360" operand="=" ifValue="0" elseValue="$" />
           <padding active="True" direction="Left" length="3" character="0" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Glareshield/ SN-894-EA3" trigger="normal" customType="" customName="FCU LCD" messageType="19" value="$" />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="19" value="$" />
         <preconditions>
           <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
         </preconditions>
@@ -135,7 +135,7 @@
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_FCU_HDG_MANAGED_DOT)" UUID="015e79b3-c73d-4d04-bfa7-08ec67826b41" />
         <test type="Float" value="1" />
         <modifiers />
-        <display type="CustomDevice" serial="Kav Glareshield/ SN-894-EA3" trigger="normal" customType="" customName="FCU LCD" messageType="11" value="$" />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="11" value="$" />
         <preconditions>
           <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
         </preconditions>
@@ -149,7 +149,7 @@
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_TRK_FPA_MODE_ACTIVE)" UUID="20864ce0-eef8-48ab-97cb-9ca8a5a0cefd" />
         <test type="Float" value="1" />
         <modifiers />
-        <display type="CustomDevice" serial="Kav Glareshield/ SN-894-EA3" trigger="normal" customType="" customName="FCU LCD" messageType="13" value="$" />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="13" value="$" />
         <preconditions>
           <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
         </preconditions>
@@ -177,7 +177,7 @@
         <modifiers>
           <padding active="True" direction="Left" length="5" character="0" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Glareshield/ SN-894-EA3" trigger="normal" customType="" customName="FCU LCD" messageType="20" value="$" />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="20" value="$" />
         <preconditions>
           <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
         </preconditions>
@@ -191,7 +191,7 @@
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_FCU_ALT_MANAGED)" UUID="74b7815d-248a-4458-836d-b095c3ed0230" />
         <test type="Float" value="1" />
         <modifiers />
-        <display type="CustomDevice" serial="Kav Glareshield/ SN-894-EA3" trigger="normal" customType="" customName="FCU LCD" messageType="12" value="$" />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="12" value="$" />
         <preconditions>
           <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
         </preconditions>
@@ -222,7 +222,7 @@
           <padding active="True" direction="Left" length="4" character="0" />
           <transformation active="True" expression="if (# &lt; 0, '-$', '+$')" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Glareshield/ SN-894-EA3" trigger="normal" customType="" customName="FCU LCD" messageType="21" value="$" />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="21" value="$" />
         <preconditions>
           <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
           <precondition type="config" active="true" ref="ac4a3707-edb9-43d0-8888-8528cc9bc9e7" operand="=" value="0" logic="and" />
@@ -257,7 +257,7 @@
           <transformation active="True" expression="if (# &lt; 0, '-$' , '+$' )" />
           <padding active="True" direction="Right" length="6" character=" " />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Glareshield/ SN-894-EA3" trigger="normal" customType="" customName="FCU LCD" messageType="21" value="$" />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="21" value="$" />
         <preconditions>
           <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
           <precondition type="config" active="true" ref="ac4a3707-edb9-43d0-8888-8528cc9bc9e7" operand="=" value="0" logic="and" />
@@ -291,7 +291,7 @@
         <modifiers>
           <comparison active="True" value="1" operand="=" ifValue="'-----'" elseValue="''" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Glareshield/ SN-894-EA3" trigger="normal" customType="" customName="FCU LCD" messageType="21" value="$" />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="21" value="$" />
         <preconditions>
           <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
           <precondition type="config" active="true" ref="f60e20ae-efd7-428f-9e1b-a1f66c7d8ed5" operand="=" value="1" logic="and" />
@@ -379,7 +379,7 @@
         <modifiers>
           <comparison active="True" value="1000" operand="&lt;" ifValue="'0$'" elseValue="$" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Glareshield/ SN-894-EA3" trigger="normal" customType="" customName="EFIS L" messageType="5" value="$" />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS L" messageType="5" value="$" />
         <preconditions>
           <precondition type="config" active="true" ref="b0a94e56-8b62-4d9a-934a-0d1f1fc740d7" operand="&lt;" value="2" logic="and" />
           <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
@@ -399,7 +399,7 @@
           <transformation active="True" expression="if (Round($,2) - Round($,0) = 0, '$.00 o', if (Round($,2) - Round($,1) = 0, '$0 o', $))" />
           <substring active="True" start="0" end="5" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Glareshield/ SN-894-EA3" trigger="normal" customType="" customName="EFIS L" messageType="5" value="$" />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS L" messageType="5" value="$" />
         <preconditions>
           <precondition type="config" active="true" ref="b0a94e56-8b62-4d9a-934a-0d1f1fc740d7" operand="&lt;" value="2" logic="and" />
           <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="=" value="1" logic="and" />
@@ -417,7 +417,7 @@
         <modifiers>
           <transformation active="True" expression="'Std '" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Glareshield/ SN-894-EA3" trigger="normal" customType="" customName="EFIS L" messageType="5" value="$" />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS L" messageType="5" value="$" />
         <preconditions>
           <precondition type="config" active="true" ref="b0a94e56-8b62-4d9a-934a-0d1f1fc740d7" operand="&gt;" value="1" logic="and" />
           <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
@@ -434,7 +434,7 @@
         <modifiers>
           <comparison active="True" value="1" operand="=" ifValue="1" elseValue="0" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Glareshield/ SN-894-EA3" trigger="normal" customType="" customName="EFIS L" messageType="3" value="$" />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS L" messageType="3" value="$" />
         <preconditions>
           <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
         </preconditions>
@@ -451,7 +451,7 @@
           <transformation active="False" expression="if( # = 0, 1 , 0)" />
           <comparison active="True" value="0" operand="=" ifValue="1" elseValue="0" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Glareshield/ SN-894-EA3" trigger="normal" customType="" customName="EFIS L" messageType="4" value="$" />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS L" messageType="4" value="$" />
         <preconditions>
           <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
         </preconditions>
@@ -511,7 +511,7 @@
         <modifiers>
           <comparison active="True" value="1000" operand="&lt;" ifValue="'0$'" elseValue="$" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Glareshield/ SN-894-EA3" trigger="normal" customType="" customName="EFIS R" messageType="5" value="$" />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS R" messageType="5" value="$" />
         <preconditions>
           <precondition type="config" active="true" ref="b0a94e56-8b62-4d9a-934a-0d1f1fc740d7" operand="&lt;" value="2" logic="and" />
           <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
@@ -531,7 +531,7 @@
           <transformation active="True" expression="if (Round($,2) - Round($,0) = 0, '$.00 o', if (Round($,2) - Round($,1) = 0, '$0 o', $))" />
           <substring active="True" start="0" end="5" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Glareshield/ SN-894-EA3" trigger="normal" customType="" customName="EFIS R" messageType="5" value="$" />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS R" messageType="5" value="$" />
         <preconditions>
           <precondition type="config" active="true" ref="b0a94e56-8b62-4d9a-934a-0d1f1fc740d7" operand="&lt;" value="2" logic="and" />
           <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="=" value="1" logic="and" />
@@ -549,7 +549,7 @@
         <modifiers>
           <transformation active="True" expression="'Std '" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Glareshield/ SN-894-EA3" trigger="normal" customType="" customName="EFIS R" messageType="5" value="$" />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS R" messageType="5" value="$" />
         <preconditions>
           <precondition type="config" active="true" ref="b0a94e56-8b62-4d9a-934a-0d1f1fc740d7" operand="&gt;" value="1" logic="and" />
           <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
@@ -566,7 +566,7 @@
         <modifiers>
           <comparison active="True" value="1" operand="=" ifValue="1" elseValue="0" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Glareshield/ SN-894-EA3" trigger="normal" customType="" customName="EFIS R" messageType="3" value="$" />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS R" messageType="3" value="$" />
         <preconditions>
           <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
         </preconditions>
@@ -583,7 +583,7 @@
           <transformation active="False" expression="if( # = 0, 1 , 0)" />
           <comparison active="True" value="0" operand="=" ifValue="1" elseValue="0" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Glareshield/ SN-894-EA3" trigger="normal" customType="" customName="EFIS R" messageType="4" value="$" />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS R" messageType="4" value="$" />
         <preconditions>
           <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
         </preconditions>
@@ -656,7 +656,7 @@
         <modifiers>
           <transformation active="True" expression="(Round($, 1))*10" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Overhead/ SN-640-5FD" trigger="normal" customType="" customName="BAT 1" messageType="3" value="$" />
+        <display type="CustomDevice" serial="Kav Overhead/ SN-FF7-AF3" trigger="normal" customType="" customName="BAT 1" messageType="3" value="$" />
         <preconditions />
         <configrefs />
       </settings>
@@ -670,7 +670,7 @@
         <modifiers>
           <transformation active="True" expression="(Round($, 1))*10" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Overhead/ SN-640-5FD" trigger="normal" customType="" customName="BAT 2" messageType="3" value="$" />
+        <display type="CustomDevice" serial="Kav Overhead/ SN-FF7-AF3" trigger="normal" customType="" customName="BAT 2" messageType="3" value="$" />
         <preconditions />
         <configrefs />
       </settings>
@@ -710,7 +710,7 @@
         <modifiers>
           <transformation active="True" expression="if(X=1,A,if(X=2,B,if(X=3,C,0)))" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Overhead/ SN-640-5FD" trigger="normal" customType="" customName="ACTIVE" messageType="2" value="$" />
+        <display type="CustomDevice" serial="Kav Overhead/ SN-FF7-AF3" trigger="normal" customType="" customName="ACTIVE" messageType="2" value="$" />
         <preconditions />
         <configrefs>
           <configref active="True" ref="f7a2e9f7-6674-4163-9112-dee3e64829fd" placeholder="C" testvalue="1" />
@@ -729,7 +729,7 @@
         <modifiers>
           <transformation active="True" expression="if(X=1,A,if(X=2,B,if(X=3,C,0)))" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Overhead/ SN-640-5FD" trigger="normal" customType="" customName="STBY-CRS" messageType="2" value="$" />
+        <display type="CustomDevice" serial="Kav Overhead/ SN-FF7-AF3" trigger="normal" customType="" customName="STBY-CRS" messageType="2" value="$" />
         <preconditions />
         <configrefs>
           <configref active="True" ref="eb52ed55-b37d-4884-b16c-c74cb1eafea3" placeholder="C" testvalue="1" />
@@ -760,7 +760,7 @@
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_RMP_L_SELECTED_MODE)" UUID="d17a285e-b483-41db-b5dd-803d7bcd76b7" />
         <test type="Float" value="1" />
         <modifiers />
-        <display type="-" serial="Kav Overhead/ SN-640-5FD" trigger="normal" pin="" pinBrightness="255" />
+        <display type="-" serial="Kav Overhead/ SN-FF7-AF3" trigger="normal" pin="" pinBrightness="255" />
         <preconditions />
         <configrefs />
       </settings>
@@ -772,7 +772,7 @@
         <source type="SimConnect" VarType="CODE" Value="(A:COM ACTIVE FREQUENCY:1,KHz)" UUID="b5a95362-411e-422d-9e6e-598b8b0bdcdf" />
         <test type="Float" value="1" />
         <modifiers />
-        <display type="-" serial="Kav Overhead/ SN-640-5FD" trigger="normal" pin="" pinBrightness="255" />
+        <display type="-" serial="Kav Overhead/ SN-FF7-AF3" trigger="normal" pin="" pinBrightness="255" />
         <preconditions />
         <configrefs />
       </settings>
@@ -784,7 +784,7 @@
         <source type="SimConnect" VarType="CODE" Value="(A:COM ACTIVE FREQUENCY:2,KHz)" UUID="b5a95362-411e-422d-9e6e-598b8b0bdcdf" />
         <test type="Float" value="1" />
         <modifiers />
-        <display type="-" serial="Kav Overhead/ SN-640-5FD" trigger="normal" pin="" pinBrightness="255" />
+        <display type="-" serial="Kav Overhead/ SN-FF7-AF3" trigger="normal" pin="" pinBrightness="255" />
         <preconditions />
         <configrefs />
       </settings>
@@ -798,7 +798,7 @@
         <modifiers>
           <transformation active="True" expression="Truncate($)" />
         </modifiers>
-        <display type="-" serial="Kav Overhead/ SN-640-5FD" trigger="normal" pin="" pinBrightness="255" />
+        <display type="-" serial="Kav Overhead/ SN-FF7-AF3" trigger="normal" pin="" pinBrightness="255" />
         <preconditions />
         <configrefs />
       </settings>
@@ -810,7 +810,7 @@
         <source type="SimConnect" VarType="CODE" Value="(A:COM STANDBY FREQUENCY:1,KHz)" UUID="0c6afa60-4a6e-405d-91a5-1d7ba95bfe11" />
         <test type="Float" value="1" />
         <modifiers />
-        <display type="-" serial="Kav Overhead/ SN-640-5FD" trigger="normal" pin="" pinBrightness="255" />
+        <display type="-" serial="Kav Overhead/ SN-FF7-AF3" trigger="normal" pin="" pinBrightness="255" />
         <preconditions />
         <configrefs />
       </settings>
@@ -824,7 +824,7 @@
         <modifiers>
           <transformation active="True" expression="$/1000" />
         </modifiers>
-        <display type="-" serial="Kav Overhead/ SN-640-5FD" trigger="normal" pin="" pinBrightness="255" />
+        <display type="-" serial="Kav Overhead/ SN-FF7-AF3" trigger="normal" pin="" pinBrightness="255" />
         <preconditions />
         <configrefs />
       </settings>
@@ -839,7 +839,7 @@
           <transformation active="True" expression="$/1000" />
           <transformation active="True" expression="Truncate($)" />
         </modifiers>
-        <display type="-" serial="Kav Overhead/ SN-640-5FD" trigger="normal" pin="" pinBrightness="255" />
+        <display type="-" serial="Kav Overhead/ SN-FF7-AF3" trigger="normal" pin="" pinBrightness="255" />
         <preconditions />
         <configrefs />
       </settings>
@@ -893,7 +893,7 @@
         <modifiers>
           <transformation active="True" expression="if(X=1,A,if(X=2,B,if(X=3,C,0)))" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Mega Pedesta/ SN-2G6-C0F" trigger="normal" customType="" customName="RMP L ACTIVE" messageType="2" value="$" />
+        <display type="CustomDevice" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" customType="" customName="RMP L ACTIVE" messageType="2" value="$" />
         <preconditions />
         <configrefs>
           <configref active="True" ref="f7a2e9f7-6674-4163-9112-dee3e64829fd" placeholder="C" testvalue="1" />
@@ -912,7 +912,7 @@
         <modifiers>
           <transformation active="True" expression="if(X=1,A,if(X=2,B,if(X=3,C,0)))" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Mega Pedesta/ SN-2G6-C0F" trigger="normal" customType="" customName="RMP L STBY-CRS" messageType="2" value="$" />
+        <display type="CustomDevice" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" customType="" customName="RMP L STBY-CRS" messageType="2" value="$" />
         <preconditions />
         <configrefs>
           <configref active="True" ref="eb52ed55-b37d-4884-b16c-c74cb1eafea3" placeholder="C" testvalue="1" />
@@ -943,7 +943,7 @@
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_RMP_L_SELECTED_MODE)" UUID="d17a285e-b483-41db-b5dd-803d7bcd76b7" />
         <test type="Float" value="1" />
         <modifiers />
-        <display type="-" serial="Kav Mega Pedesta/ SN-2G6-C0F" trigger="normal" pin="" pinBrightness="255" />
+        <display type="-" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" pin="" pinBrightness="255" />
         <preconditions />
         <configrefs />
       </settings>
@@ -955,7 +955,7 @@
         <source type="SimConnect" VarType="CODE" Value="(A:COM ACTIVE FREQUENCY:1,KHz)" UUID="b5a95362-411e-422d-9e6e-598b8b0bdcdf" />
         <test type="Float" value="1" />
         <modifiers />
-        <display type="-" serial="Kav Mega Pedesta/ SN-2G6-C0F" trigger="normal" pin="" pinBrightness="255" />
+        <display type="-" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" pin="" pinBrightness="255" />
         <preconditions />
         <configrefs />
       </settings>
@@ -967,7 +967,7 @@
         <source type="SimConnect" VarType="CODE" Value="(A:COM ACTIVE FREQUENCY:2,KHz)" UUID="b5a95362-411e-422d-9e6e-598b8b0bdcdf" />
         <test type="Float" value="1" />
         <modifiers />
-        <display type="-" serial="Kav Mega Pedesta/ SN-2G6-C0F" trigger="normal" pin="" pinBrightness="255" />
+        <display type="-" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" pin="" pinBrightness="255" />
         <preconditions />
         <configrefs />
       </settings>
@@ -981,7 +981,7 @@
         <modifiers>
           <transformation active="True" expression="Truncate($)" />
         </modifiers>
-        <display type="-" serial="Kav Mega Pedesta/ SN-2G6-C0F" trigger="normal" pin="" pinBrightness="255" />
+        <display type="-" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" pin="" pinBrightness="255" />
         <preconditions />
         <configrefs />
       </settings>
@@ -993,7 +993,7 @@
         <source type="SimConnect" VarType="CODE" Value="(A:COM STANDBY FREQUENCY:1,KHz)" UUID="0c6afa60-4a6e-405d-91a5-1d7ba95bfe11" />
         <test type="Float" value="1" />
         <modifiers />
-        <display type="-" serial="Kav Mega Pedesta/ SN-2G6-C0F" trigger="normal" pin="" pinBrightness="255" />
+        <display type="-" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" pin="" pinBrightness="255" />
         <preconditions />
         <configrefs />
       </settings>
@@ -1007,7 +1007,7 @@
         <modifiers>
           <transformation active="True" expression="$/1000" />
         </modifiers>
-        <display type="-" serial="Kav Mega Pedesta/ SN-2G6-C0F" trigger="normal" pin="" pinBrightness="255" />
+        <display type="-" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" pin="" pinBrightness="255" />
         <preconditions />
         <configrefs />
       </settings>
@@ -1022,7 +1022,7 @@
           <transformation active="True" expression="$/1000" />
           <transformation active="True" expression="Truncate($)" />
         </modifiers>
-        <display type="-" serial="Kav Mega Pedesta/ SN-2G6-C0F" trigger="normal" pin="" pinBrightness="255" />
+        <display type="-" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" pin="" pinBrightness="255" />
         <preconditions />
         <configrefs />
       </settings>
@@ -1062,7 +1062,7 @@
         <modifiers>
           <transformation active="True" expression="if(X=1,A,if(X=2,B,if(X=3,C,0)))" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Mega Pedesta/ SN-2G6-C0F" trigger="normal" customType="" customName="RMP R ACTIVE" messageType="2" value="$" />
+        <display type="CustomDevice" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" customType="" customName="RMP R ACTIVE" messageType="2" value="$" />
         <preconditions />
         <configrefs>
           <configref active="True" ref="9105c587-cdb0-4c4f-992a-ec4e1c024b85" placeholder="C" testvalue="1" />
@@ -1081,7 +1081,7 @@
         <modifiers>
           <transformation active="True" expression="if(X=1,A,if(X=2,B,if(X=3,C,0)))" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Mega Pedesta/ SN-2G6-C0F" trigger="normal" customType="" customName="RMP R STBY-CRS" messageType="2" value="$" />
+        <display type="CustomDevice" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" customType="" customName="RMP R STBY-CRS" messageType="2" value="$" />
         <preconditions />
         <configrefs>
           <configref active="True" ref="3f576e2a-f4c5-4245-b342-0f5eb68ce473" placeholder="C" testvalue="1" />
@@ -1112,7 +1112,7 @@
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_RMP_R_SELECTED_MODE)" UUID="2a0993fd-857f-4632-a9c0-5e90bee04089" />
         <test type="Float" value="1" />
         <modifiers />
-        <display type="-" serial="Kav Mega Pedesta/ SN-2G6-C0F" trigger="normal" pin="" pinBrightness="255" />
+        <display type="-" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" pin="" pinBrightness="255" />
         <preconditions />
         <configrefs />
       </settings>
@@ -1124,7 +1124,7 @@
         <source type="SimConnect" VarType="CODE" Value="(A:COM ACTIVE FREQUENCY:1,KHz)" UUID="b5a95362-411e-422d-9e6e-598b8b0bdcdf" />
         <test type="Float" value="1" />
         <modifiers />
-        <display type="-" serial="Kav Mega Pedesta/ SN-2G6-C0F" trigger="normal" pin="" pinBrightness="255" />
+        <display type="-" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" pin="" pinBrightness="255" />
         <preconditions />
         <configrefs />
       </settings>
@@ -1136,7 +1136,7 @@
         <source type="SimConnect" VarType="CODE" Value="(A:COM ACTIVE FREQUENCY:2,KHz)" UUID="b5a95362-411e-422d-9e6e-598b8b0bdcdf" />
         <test type="Float" value="1" />
         <modifiers />
-        <display type="-" serial="Kav Mega Pedesta/ SN-2G6-C0F" trigger="normal" pin="" pinBrightness="255" />
+        <display type="-" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" pin="" pinBrightness="255" />
         <preconditions />
         <configrefs />
       </settings>
@@ -1150,7 +1150,7 @@
         <modifiers>
           <transformation active="True" expression="Truncate($)" />
         </modifiers>
-        <display type="-" serial="Kav Mega Pedesta/ SN-2G6-C0F" trigger="normal" pin="" pinBrightness="255" />
+        <display type="-" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" pin="" pinBrightness="255" />
         <preconditions />
         <configrefs />
       </settings>
@@ -1164,7 +1164,7 @@
         <modifiers>
           <transformation active="True" expression="Truncate($/1000)" />
         </modifiers>
-        <display type="-" serial="Kav Mega Pedesta/ SN-2G6-C0F" trigger="normal" pin="" pinBrightness="255" />
+        <display type="-" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" pin="" pinBrightness="255" />
         <preconditions />
         <configrefs />
       </settings>
@@ -1176,7 +1176,7 @@
         <source type="SimConnect" VarType="CODE" Value="(A:COM STANDBY FREQUENCY:2,KHz)" UUID="0c6afa60-4a6e-405d-91a5-1d7ba95bfe11" />
         <test type="Float" value="1" />
         <modifiers />
-        <display type="-" serial="Kav Mega Pedesta/ SN-2G6-C0F" trigger="normal" pin="" pinBrightness="255" />
+        <display type="-" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" pin="" pinBrightness="255" />
         <preconditions />
         <configrefs />
       </settings>
@@ -1191,7 +1191,7 @@
           <transformation active="True" expression="$/1000" />
           <transformation active="True" expression="Truncate($)" />
         </modifiers>
-        <display type="-" serial="Kav Mega Pedesta/ SN-2G6-C0F" trigger="normal" pin="" pinBrightness="255" />
+        <display type="-" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" pin="" pinBrightness="255" />
         <preconditions />
         <configrefs />
       </settings>
@@ -1217,7 +1217,7 @@
         <source type="SimConnect" VarType="CODE" Value="(A:TRANSPONDER CODE:1, Number)" UUID="d52e9a47-61c3-496b-b918-c5aa2fcf4ee7" />
         <test type="Float" value="1" />
         <modifiers />
-        <display type="CustomDevice" serial="Kav Mega Pedesta/ SN-2G6-C0F" trigger="normal" customType="" customName="TCAS" messageType="3" value="$" />
+        <display type="CustomDevice" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" customType="" customName="TCAS" messageType="3" value="$" />
         <preconditions />
         <configrefs />
       </settings>
@@ -1245,7 +1245,7 @@
         <modifiers>
           <transformation active="True" expression="if($&lt;=0,1,0)" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Mega Pedesta/ SN-2G6-C0F" trigger="normal" customType="" customName="RUDDER TRIM" messageType="0" value="$" />
+        <display type="CustomDevice" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" customType="" customName="RUDDER TRIM" messageType="0" value="$" />
         <preconditions />
         <configrefs />
       </settings>
@@ -1259,7 +1259,7 @@
         <modifiers>
           <transformation active="True" expression="if($&gt;0,1,0)" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Mega Pedesta/ SN-2G6-C0F" trigger="normal" customType="" customName="RUDDER TRIM" messageType="1" value="$" />
+        <display type="CustomDevice" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" customType="" customName="RUDDER TRIM" messageType="1" value="$" />
         <preconditions />
         <configrefs />
       </settings>
@@ -1274,7 +1274,7 @@
           <transformation active="True" expression="Round($,1)" />
           <transformation active="True" expression="$*10" />
         </modifiers>
-        <display type="CustomDevice" serial="Kav Mega Pedesta/ SN-2G6-C0F" trigger="normal" customType="" customName="RUDDER TRIM" messageType="3" value="$" />
+        <display type="CustomDevice" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" customType="" customName="RUDDER TRIM" messageType="3" value="$" />
         <preconditions />
         <configrefs />
       </settings>
@@ -1308,4 +1308,3 @@
   </outputs>
   <inputs />
 </MobiflightConnector>
-<!-- Created by James Kavanagh and Ralf (@Elral) -->


### PR DESCRIPTION
## Clean up new function names & Config/Profile Update

Fixes #25 - New Function Names (For Strings) Are Confusing

1) Renamed the new functions in the FCU & EFIS devices. This now makes it clearer which functions are supported for v2.5.3 onwards, and which ones are legacy.
2) Updated the boards to ensure that v2.5.4 is the lastest version.
3) Updated the board configs to have the new pin order. Updated the `All-In-One` config for the FBWA320 to check everything is working as expected.
4) Updated the board JSON files (FCU & EFIS only) to v1.5.0.
