### PR TITLE
New Fenix Profiles & 'Annuciator Test' functions for all displays

### DIFF
--- a/KAV_Simulation/Community/boards/kav_mega.board.json
+++ b/KAV_Simulation/Community/boards/kav_mega.board.json
@@ -37,7 +37,7 @@
     "DelayAfterFirmwareUpdate": 0,
     "FirmwareBaseName": "kav_mega",
     "FirmwareExtension": "hex",
-    "LatestFirmwareVersion": "2.5.4",
+    "LatestFirmwareVersion": "2.5.5",
     "FriendlyName": "Kav Mega",
     "MobiFlightType": "Kav Mega",
     "ResetFirmwareFile": "reset.arduino_mega_1_0_2.hex",

--- a/KAV_Simulation/Community/boards/kav_pico.board.json
+++ b/KAV_Simulation/Community/boards/kav_pico.board.json
@@ -20,7 +20,7 @@
     "FirmwareBaseName": "kav_raspberrypico",
     "FirmwareExtension": "uf2",
     "FriendlyName": "Kav RaspiPico",
-    "LatestFirmwareVersion": "2.5.4",
+    "LatestFirmwareVersion": "2.5.5",
     "MobiFlightType": "Kav RaspiPico",
     "ResetFirmwareFile": "reset.raspberry_pico_flash_nuke.uf2",
     "CustomDeviceTypes": [

--- a/KAV_Simulation/Community/devices/kav_battery.device.json
+++ b/KAV_Simulation/Community/devices/kav_battery.device.json
@@ -40,6 +40,11 @@
       "id": 3,
       "label": "Set value w/ V",
       "description": "$ will set the value of the LCD with 'V' character enabled"
+    },
+    {
+      "id": 4,
+      "label": "(v2.5.3+) Annunciator Test Mode",
+      "description": "$ = 1 will display all Segments, $ = 0 will clear display"
     }
   ]
 }

--- a/KAV_Simulation/Community/devices/kav_efis.device.json
+++ b/KAV_Simulation/Community/devices/kav_efis.device.json
@@ -50,6 +50,11 @@
       "id": 5,
       "label": "(v2.5.4+) Show Value (STRING)",
       "description": "$ will be displayed"
+    },
+    {
+      "id": 6,
+      "label": "(v2.5.3+) Annunciator Test Mode",
+      "description": "$ = 1 will display all EFIS Segments, $ = 0 will clear display"
     }
   ]
 }

--- a/KAV_Simulation/Community/devices/kav_fcu.device.json
+++ b/KAV_Simulation/Community/devices/kav_fcu.device.json
@@ -130,6 +130,11 @@
       "id": 22,
       "label": "(v2.5.3+) Toggle Speed/Mach mode",
       "description": "$ = 1 will display Mach labels, $ = 2 will display Speed labels"
+    },
+    {
+      "id": 23,
+      "label": "(v2.5.3+) Annunciator Test Mode",
+      "description": "$ = 1 will display all FCU Segments, $ = 0 will clear display"
     }
   ]
 }

--- a/KAV_Simulation/Community/devices/kav_rad_tcas.device.json
+++ b/KAV_Simulation/Community/devices/kav_rad_tcas.device.json
@@ -40,6 +40,11 @@
       "id": 3,
       "label": "Set value TCAS",
       "description": "$ will show the value on the display for TCAS"
+    },
+    {
+      "id": 4,
+      "label": "(v2.5.3+) Annunciator Test Mode",
+      "description": "$ = 1 will display all Segments, $ = 0 will clear display"
     }
   ]
 }

--- a/KAV_Simulation/Community/devices/kav_rudder.device.json
+++ b/KAV_Simulation/Community/devices/kav_rudder.device.json
@@ -55,6 +55,11 @@
       "id": 6,
       "label": "Set value w/ 'L' or 'R'",
       "description": "$ will set the value of the display with the 'L' or 'R' character"
+    },
+    {
+      "id": 7,
+      "label": "(v2.5.3+) Annunciator Test Mode",
+      "description": "$ = 1 will display all Segments, $ = 0 will clear display"
     }
   ]
 }

--- a/KAV_Simulation/Community/profiles/msfs2020/Fenix A320/FENIX - KAV FIRMWARE V2-0-0-378 (QUARTZ).mcc
+++ b/KAV_Simulation/Community/profiles/msfs2020/Fenix A320/FENIX - KAV FIRMWARE V2-0-0-378 (QUARTZ).mcc
@@ -1,0 +1,685 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<MobiflightConnector>
+  <outputs>
+    <config guid="7db8da5f-020b-4185-91cd-604111ba6edd">
+      <active>false</active>
+      <description>FCU CONFIG</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <comparison active="True" value="" operand="=" ifValue="1" elseValue="0" />
+        </modifiers>
+        <display type="" serial="" trigger="change" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="0045cac7-7b32-43e6-a8a9-a57dd4b45936">
+      <active>true</active>
+      <description>FCU - Speed Value</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:FNX2PLD_fcuSpd, Knots)" UUID="82853f1e-dcc2-4748-bb34-c145ef748598" />
+        <test type="Float" value="-1" />
+        <modifiers>
+          <transformation active="True" expression="Round($,0)" />
+          <comparison active="False" value="0" operand="&lt;=" ifValue="'---'" elseValue="$" />
+          <padding active="True" direction="Left" length="3" character="0" />
+          <transformation active="True" expression="if(#=1, '---', $)" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="18" value="$" />
+        <preconditions>
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
+          <precondition type="config" active="true" ref="97f70f49-f7c5-4c92-af0a-a88bcdab7ecc" operand="=" value="1" logic="and" />
+        </preconditions>
+        <configrefs>
+          <configref active="True" ref="7b3778a6-8b08-46ee-8042-a1d037243b95" placeholder="#" testvalue="1" />
+        </configrefs>
+      </settings>
+    </config>
+    <config guid="53041b63-611c-4bbf-a40b-8797b62db163">
+      <active>true</active>
+      <description>FCU - Mach Value</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:FNX2PLD_fcuSpd, Knots)" UUID="82853f1e-dcc2-4748-bb34-c145ef748598" />
+        <test type="Float" value="-1" />
+        <modifiers>
+          <comparison active="False" value="0" operand="&lt;" ifValue="'---'" elseValue="$" />
+          <transformation active="True" expression="0.$" />
+          <transformation active="True" expression="if(#=1, '---', $)" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="18" value="$" />
+        <preconditions>
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
+          <precondition type="config" active="true" ref="97f70f49-f7c5-4c92-af0a-a88bcdab7ecc" operand="=" value="0" logic="and" />
+        </preconditions>
+        <configrefs>
+          <configref active="True" ref="7b3778a6-8b08-46ee-8042-a1d037243b95" placeholder="#" testvalue="1" />
+        </configrefs>
+      </settings>
+    </config>
+    <config guid="7b3778a6-8b08-46ee-8042-a1d037243b95">
+      <active>true</active>
+      <description>FCU - SPD/MACH Dashed</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:FNX2PLD_fcuSpdDashed)" UUID="18d562e5-e114-40cc-a2d5-c34a712fe017" />
+        <test type="Float" value="-1" />
+        <modifiers />
+        <display type="-" serial="Kav Glareshield/ SN-E98-277" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions>
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
+          <precondition type="config" active="true" ref="97f70f49-f7c5-4c92-af0a-a88bcdab7ecc" operand="=" value="0" logic="and" />
+        </preconditions>
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="2db0b156-a792-416a-970c-b2f7d8b62458">
+      <active>true</active>
+      <description>FCU - SPD Dot</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_SPEED_MANAGED)" UUID="28029cad-8379-419c-ba1f-589cada617fa" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="10" value="$" />
+        <preconditions>
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
+        </preconditions>
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="97f70f49-f7c5-4c92-af0a-a88bcdab7ecc">
+      <active>true</active>
+      <description>FCU - Set Speed Label</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_MACH_MODE)" UUID="cf9c73a0-ab34-455b-866d-f47c09d19336" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <comparison active="True" value="0" operand="=" ifValue="1" elseValue="0" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="14" value="$" />
+        <preconditions>
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
+        </preconditions>
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="5c7d2d7c-d849-4a62-a2f5-7bddef3f1c57">
+      <active>true</active>
+      <description>FCU - Set Mach Label</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_MACH_MODE)" UUID="cf9c73a0-ab34-455b-866d-f47c09d19336" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="15" value="$" />
+        <preconditions>
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
+        </preconditions>
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="1938a7b0-ef7f-47e8-a332-4e856afcdcb1">
+      <active>false</active>
+      <description>-</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="6af2a5a4-41bb-47eb-aabc-8dbe958a5de1">
+      <active>true</active>
+      <description>FCU - HDG Show Value</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:FNX2PLD_fcuHdg,Degrees)" UUID="93407070-d47f-48a7-9537-4d8ca18f0d89" />
+        <test type="Float" value="0" />
+        <modifiers>
+          <transformation active="True" expression="Round($, 0)" />
+          <comparison active="False" value="0" operand="&lt;" ifValue="'---'" elseValue="$" />
+          <transformation active="True" expression="if(#=1, '---', $)" />
+          <comparison active="True" value="360" operand="=" ifValue="0" elseValue="$" />
+          <padding active="True" direction="Left" length="3" character="0" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="19" value="$" />
+        <preconditions>
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
+        </preconditions>
+        <configrefs>
+          <configref active="True" ref="f0eee59d-33e7-48d0-a299-7f0492e4f81a" placeholder="#" testvalue="1" />
+        </configrefs>
+      </settings>
+    </config>
+    <config guid="f0eee59d-33e7-48d0-a299-7f0492e4f81a">
+      <active>true</active>
+      <description>FCU - HDG Dashed</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:FNX2PLD_fcuHdgDashed)" UUID="1cf6edf3-bf5e-49ea-b91f-b291e9b00a36" />
+        <test type="Float" value="0" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="e9e662ce-3758-44c8-98bc-a9215ab4f238">
+      <active>true</active>
+      <description>FCU - HDG Set/Unset Dot</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_HEADING_MANAGED)" UUID="b7a4af17-9112-4a88-9629-e10acdd604e8" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="11" value="$" />
+        <preconditions>
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
+        </preconditions>
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="5c5ddbfc-d1db-48f0-bc2e-d668b0882c47">
+      <active>true</active>
+      <description>FCU - HDG/TRK Toggle</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_TRACK_FPA_MODE)" UUID="0c24f12b-0016-4da7-b941-587a581e5686" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="13" value="$" />
+        <preconditions>
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
+        </preconditions>
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="c4b60d5d-7c6e-4b78-a885-d772a6560224">
+      <active>false</active>
+      <description>-</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="9605bc95-99b8-4396-9e62-a53e4158adb6">
+      <active>true</active>
+      <description>FCU - ALT Show Value</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:FNX2PLD_fcuAlt, Feet)" UUID="a7c09623-b340-441c-9087-4bbec9b41bc4" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <padding active="True" direction="Left" length="5" character="0" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="20" value="$" />
+        <preconditions>
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
+        </preconditions>
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="7a58c836-44b8-4c79-8703-25a73925c4fd">
+      <active>true</active>
+      <description>FCU - ALT Set/Unset Dot</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_ALTITUDE_MANAGED)" UUID="bca70365-cd7c-4408-ad8e-4d7c5f578166" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="12" value="$" />
+        <preconditions>
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
+        </preconditions>
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="0e6bcd9b-5752-4b17-95a2-274231d30cac">
+      <active>false</active>
+      <description>-</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="284222fc-9b8d-4383-83a0-e13a718e0e90">
+      <active>true</active>
+      <description>FCU - VS Value</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:FNX2PLD_fcuVs, Ft/min)" UUID="8689ddbb-7786-4805-add4-05cd92ea249c" />
+        <test type="String" value="01oo" />
+        <modifiers>
+          <transformation active="True" expression="Abs($/100)" />
+          <comparison active="True" value="0" operand="=" ifValue="'00oo'" elseValue="'$oo'" />
+          <padding active="True" direction="Left" length="4" character="0" />
+          <transformation active="True" expression="if (# &lt; 0, '-$', '+$')" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="21" value="$" />
+        <preconditions>
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
+          <precondition type="config" active="true" ref="ac4a3707-edb9-43d0-8888-8528cc9bc9e7" operand="=" value="''" logic="and" />
+          <precondition type="config" active="true" ref="7f01367f-bbf2-491b-8711-eadbfb6c3a49" operand="=" value="0" logic="and" />
+        </preconditions>
+        <configrefs>
+          <configref active="True" ref="c7a379d3-0c74-4c5d-b236-00319c6204f2" placeholder="#" testvalue="1" />
+        </configrefs>
+      </settings>
+    </config>
+    <config guid="c7a379d3-0c74-4c5d-b236-00319c6204f2">
+      <active>true</active>
+      <description>FCU -VS Value helper</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:FNX2PLD_fcuVs, Ft/min)" UUID="8689ddbb-7786-4805-add4-05cd92ea249c" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="d439076e-a7a5-47b0-aed1-945a4d82156c">
+      <active>true</active>
+      <description>FCU - FPA Value</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:FNX2PLD_fcuVs, Ft/min)" UUID="8689ddbb-7786-4805-add4-05cd92ea249c" />
+        <test type="Float" value="-0.1" />
+        <modifiers>
+          <transformation active="True" expression="Round(Abs($), 1)" />
+          <transformation active="True" expression="if (Round($,1) - Round($,0) = 0, '$.0   0', '$   0')" />
+          <transformation active="True" expression="if (# &lt; 0, '-$' , '+$' )" />
+          <padding active="True" direction="Right" length="6" character=" " />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="21" value="$" />
+        <preconditions>
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
+          <precondition type="config" active="true" ref="ac4a3707-edb9-43d0-8888-8528cc9bc9e7" operand="=" value="0" logic="and" />
+          <precondition type="config" active="true" ref="7f01367f-bbf2-491b-8711-eadbfb6c3a49" operand="=" value="1" logic="and" />
+        </preconditions>
+        <configrefs>
+          <configref active="True" ref="de956b07-4e88-4cbf-8bb8-a93814c94d2a" placeholder="#" testvalue="0" />
+        </configrefs>
+      </settings>
+    </config>
+    <config guid="de956b07-4e88-4cbf-8bb8-a93814c94d2a">
+      <active>true</active>
+      <description>FCU - FPA Value helper</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:FNX2PLD_fcuVs, Ft/min)" UUID="8689ddbb-7786-4805-add4-05cd92ea249c" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions>
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
+        </preconditions>
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="ac4a3707-edb9-43d0-8888-8528cc9bc9e7">
+      <active>true</active>
+      <description>FCU - VS Dashes</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:FNX2PLD_fcuVsDashed)" UUID="5186d8b0-8a38-49fc-a029-ccb5a8d12687" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <comparison active="True" value="1" operand="=" ifValue="'-----'" elseValue="''" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="21" value="$" />
+        <preconditions>
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
+          <precondition type="config" active="true" ref="f60e20ae-efd7-428f-9e1b-a1f66c7d8ed5" operand="=" value="1" logic="and" />
+        </preconditions>
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="f60e20ae-efd7-428f-9e1b-a1f66c7d8ed5">
+      <active>true</active>
+      <description>FCU - VS Dashes Mode</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:FNX2PLD_fcuVsDashed)" UUID="5186d8b0-8a38-49fc-a029-ccb5a8d12687" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions>
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
+        </preconditions>
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="7f01367f-bbf2-491b-8711-eadbfb6c3a49">
+      <active>true</active>
+      <description>FCU - VS/FPA Mode</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_TRACK_FPA_MODE)" UUID="0c24f12b-0016-4da7-b941-587a581e5686" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="db2fbafc-0142-400a-8005-df80f3a7964b">
+      <active>false</active>
+      <description>-</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="False" expression="$" />
+          <comparison active="True" value="" operand="=" ifValue="1" elseValue="0" />
+        </modifiers>
+        <display type="" serial="-" trigger="change" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="9d91a242-ae2c-4eb2-80cc-91dd53b5a803">
+      <active>false</active>
+      <description>EFIS L CONFIG</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="False" expression="$" />
+          <comparison active="True" value="" operand="=" ifValue="1" elseValue="0" />
+        </modifiers>
+        <display type="" serial="-" trigger="change" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="25ce1038-659a-4005-a90d-7a670f0387c2">
+      <active>true</active>
+      <description>EFIS L - Show QFE/QNH Value mbar</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value=" (A:KOHLSMAN SETTING HG, inHg)" UUID="a2980123-8105-4f5c-a207-5ae1d5a28096" />
+        <test type="Float" value="0.1234" />
+        <modifiers>
+          <transformation active="True" expression="Truncate($*33.88)" />
+          <comparison active="True" value="1000" operand="&lt;" ifValue="'0$'" elseValue="$" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS L" messageType="5" value="$" />
+        <preconditions>
+          <precondition type="config" active="true" ref="b0a94e56-8b62-4d9a-934a-0d1f1fc740d7" operand="=" value="1" logic="and" />
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
+          <precondition type="config" active="true" ref="78a30b5d-31fe-4ebb-8b16-714af1edb354" operand="!=" value="0" logic="and" />
+        </preconditions>
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="8660c2bd-f65b-47f2-8447-f47e03665a29">
+      <active>true</active>
+      <description>EFIS L - Show QNH Value hPa</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value=" (A:KOHLSMAN SETTING HG, inHg)" UUID="a2980123-8105-4f5c-a207-5ae1d5a28096" />
+        <test type="Float" value="0.1234" />
+        <modifiers>
+          <transformation active="False" expression="$/33.84" />
+          <transformation active="True" expression="Round($, 2)" />
+          <transformation active="True" expression="if (Round($,2) - Round($,0) = 0, '$.00 o', if (Round($,2) - Round($,1) = 0, '$0 o', $))" />
+          <substring active="True" start="0" end="5" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS L" messageType="5" value="$" />
+        <preconditions>
+          <precondition type="config" active="true" ref="b0a94e56-8b62-4d9a-934a-0d1f1fc740d7" operand="=" value="0" logic="and" />
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="=" value="1" logic="and" />
+          <precondition type="config" active="true" ref="78a30b5d-31fe-4ebb-8b16-714af1edb354" operand="!=" value="0" logic="and" />
+        </preconditions>
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="f59ea400-6153-4f57-b1d8-b98f2cb11d1b">
+      <active>true</active>
+      <description>EFIS L - Show STD</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_EFIS1_QNH)" UUID="0468d4e6-7488-4c67-a41a-23ede3e89391" />
+        <test type="Float" value="0" />
+        <modifiers>
+          <transformation active="True" expression="'Std '" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS L" messageType="5" value="$" />
+        <preconditions>
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
+          <precondition type="config" active="true" ref="78a30b5d-31fe-4ebb-8b16-714af1edb354" operand="=" value="0" logic="and" />
+        </preconditions>
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="78a30b5d-31fe-4ebb-8b16-714af1edb354">
+      <active>true</active>
+      <description>EFIS L - Show STD Helper</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_EFIS1_QNH)" UUID="0468d4e6-7488-4c67-a41a-23ede3e89391" />
+        <test type="Float" value="0" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="dc853165-1e17-4813-a517-78de0d41a09f">
+      <active>true</active>
+      <description>EFIS L - Set QNH Label</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_EFIS1_QNH)" UUID="0468d4e6-7488-4c67-a41a-23ede3e89391" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <comparison active="True" value="1" operand="=" ifValue="1" elseValue="0" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS L" messageType="3" value="$" />
+        <preconditions>
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
+        </preconditions>
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="82406b5f-8065-47d7-bff2-f930822a66e8">
+      <active>true</active>
+      <description>EFIS L - Set QFE Label</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_EFIS1_QNH)" UUID="0468d4e6-7488-4c67-a41a-23ede3e89391" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="False" expression="if( # = 0, 1 , 0)" />
+          <comparison active="True" value="2" operand="=" ifValue="1" elseValue="0" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS L" messageType="4" value="$" />
+        <preconditions>
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
+        </preconditions>
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="b0a94e56-8b62-4d9a-934a-0d1f1fc740d7">
+      <active>true</active>
+      <description>EFIS L - State Condition (0=QFE, 1=QNH, 2/3=STD)</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:S_FCU_EFIS1_BARO_MODE)" UUID="b192b3b7-e6ee-444a-8349-bd9fa0c074f6" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="False" expression="$" />
+          <comparison active="False" value="" operand="" ifValue="" elseValue="" />
+        </modifiers>
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="3c7ca066-a861-40eb-a5e7-2089f21b0bc3">
+      <active>false</active>
+      <description>-</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <comparison active="True" value="" operand="=" ifValue="1" elseValue="0" />
+        </modifiers>
+        <display type="" serial="-" trigger="change" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="7ac72c64-5a91-430d-b8ac-68e7933f9826">
+      <active>false</active>
+      <description>EFIS R CONFIG</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <comparison active="True" value="" operand="=" ifValue="1" elseValue="0" />
+        </modifiers>
+        <display type="" serial="-" trigger="change" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="3ced3eb3-d738-494e-b58c-8a23f67a456f">
+      <active>true</active>
+      <description>EFIS R - Show QFE/QNH Value mbar</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value=" (A:KOHLSMAN SETTING HG, inHg)" UUID="a2980123-8105-4f5c-a207-5ae1d5a28096" />
+        <test type="Float" value="0.1234" />
+        <modifiers>
+          <transformation active="True" expression="Truncate($*33.88)" />
+          <comparison active="True" value="1000" operand="&lt;" ifValue="'0$'" elseValue="$" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS R" messageType="5" value="$" />
+        <preconditions>
+          <precondition type="config" active="true" ref="b0a94e56-8b62-4d9a-934a-0d1f1fc740d7" operand="=" value="1" logic="and" />
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
+          <precondition type="config" active="true" ref="78a30b5d-31fe-4ebb-8b16-714af1edb354" operand="!=" value="0" logic="and" />
+        </preconditions>
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="f7ddb69c-26d6-42f5-92c7-e1f7719cbea5">
+      <active>true</active>
+      <description>EFIS R - Show QNH Value hPa</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value=" (A:KOHLSMAN SETTING HG, inHg)" UUID="a2980123-8105-4f5c-a207-5ae1d5a28096" />
+        <test type="Float" value="0.1234" />
+        <modifiers>
+          <transformation active="False" expression="$/33.84" />
+          <transformation active="True" expression="Round($, 2)" />
+          <transformation active="True" expression="if (Round($,2) - Round($,0) = 0, '$.00 o', if (Round($,2) - Round($,1) = 0, '$0 o', $))" />
+          <substring active="True" start="0" end="5" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS R" messageType="5" value="$" />
+        <preconditions>
+          <precondition type="config" active="true" ref="b0a94e56-8b62-4d9a-934a-0d1f1fc740d7" operand="=" value="0" logic="and" />
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="=" value="1" logic="and" />
+          <precondition type="config" active="true" ref="78a30b5d-31fe-4ebb-8b16-714af1edb354" operand="!=" value="0" logic="and" />
+        </preconditions>
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="cceaa395-a853-46a0-ad66-e824b4b08d85">
+      <active>true</active>
+      <description>EFIS R - Show STD</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_EFIS1_QNH)" UUID="0468d4e6-7488-4c67-a41a-23ede3e89391" />
+        <test type="Float" value="0" />
+        <modifiers>
+          <transformation active="True" expression="'Std '" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS R" messageType="5" value="$" />
+        <preconditions>
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
+          <precondition type="config" active="true" ref="78a30b5d-31fe-4ebb-8b16-714af1edb354" operand="=" value="0" logic="and" />
+        </preconditions>
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="d90dffe1-8931-4475-8739-ceccd90f1fcb">
+      <active>true</active>
+      <description>EFIS R - Show STD Helper</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_EFIS1_QNH)" UUID="0468d4e6-7488-4c67-a41a-23ede3e89391" />
+        <test type="Float" value="0" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="8a46fe1e-f731-48d1-8b27-c3853246ce68">
+      <active>true</active>
+      <description>EFIS R - Set QNH Label</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_EFIS1_QNH)" UUID="0468d4e6-7488-4c67-a41a-23ede3e89391" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <comparison active="True" value="1" operand="=" ifValue="1" elseValue="0" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS R" messageType="3" value="$" />
+        <preconditions>
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
+        </preconditions>
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="bd79cb3a-a57f-45d2-b460-98bf661ddba0">
+      <active>true</active>
+      <description>EFIS R - Set QFE Label</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_EFIS1_QNH)" UUID="0468d4e6-7488-4c67-a41a-23ede3e89391" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="False" expression="if( # = 0, 1 , 0)" />
+          <comparison active="True" value="2" operand="=" ifValue="1" elseValue="0" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS R" messageType="4" value="$" />
+        <preconditions>
+          <precondition type="config" active="true" ref="a9c996db-76cb-4e02-98bd-44df3da839a9" operand="&gt;=" value="1" logic="and" />
+        </preconditions>
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="0619edef-0e9e-4bc6-b8e8-3bf876549d04">
+      <active>true</active>
+      <description>EFIS R - State Condition (0=QFE, 1=QNH, 2/3=STD)</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:S_FCU_EFIS1_BARO_MODE)" UUID="b192b3b7-e6ee-444a-8349-bd9fa0c074f6" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="False" expression="$" />
+          <comparison active="False" value="" operand="" ifValue="" elseValue="" />
+        </modifiers>
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="da9646b7-5aa9-4fb4-82a4-dc1a7e223565">
+      <active>false</active>
+      <description>-</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <comparison active="True" value="" operand="=" ifValue="1" elseValue="0" />
+        </modifiers>
+        <display type="" serial="-" trigger="change" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="a9c996db-76cb-4e02-98bd-44df3da839a9">
+      <active>true</active>
+      <description>AC BUS IS ON</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_OH_ELEC_AC_ESS_FEED_L)" UUID="ecafa1b5-3538-4da5-8a1d-450c8ac04673" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="1" />
+        </modifiers>
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+  </outputs>
+  <inputs />
+</MobiflightConnector>

--- a/KAV_Simulation/Community/profiles/msfs2020/Fenix A320/FENIX - KAV FIRMWARE V2-0-0-392 (FULL COCKPIT - NO QUARTZ).mcc
+++ b/KAV_Simulation/Community/profiles/msfs2020/Fenix A320/FENIX - KAV FIRMWARE V2-0-0-392 (FULL COCKPIT - NO QUARTZ).mcc
@@ -1,0 +1,671 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<MobiflightConnector>
+  <outputs>
+    <config guid="5a1bf488-659d-4c25-98bf-ffd43dd20a94">
+      <active>false</active>
+      <description>FCU CONFIG</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <comparison active="True" value="" operand="=" ifValue="1" elseValue="0" />
+        </modifiers>
+        <display type="" serial="-" trigger="change" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="56756680-25cd-4f2b-9ca1-2065fd60574a">
+      <active>true</active>
+      <description>SPD</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_FCU_SPEED)" UUID="ee3f0a8c-fb85-430b-8659-5597c6b66a4f" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="if(#=1, '---', if($&lt;100, '0.$', $))" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="18" value="$" />
+        <preconditions />
+        <configrefs>
+          <configref active="True" ref="7a059f7e-49f0-44e5-b136-eac092e40b71" placeholder="#" testvalue="1" />
+        </configrefs>
+      </settings>
+    </config>
+    <config guid="7a059f7e-49f0-44e5-b136-eac092e40b71">
+      <active>true</active>
+      <description>SPD DASHES</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:B_FCU_SPEED_DASHED)" UUID="0" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="a08b884c-9512-4967-86bb-79104ebf3139">
+      <active>true</active>
+      <description>SPD DOT</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_SPEED_MANAGED)" UUID="28029cad-8379-419c-ba1f-589cada617fa" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="10" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="26917f9f-f6ab-40d7-b2f8-e0591e555713">
+      <active>true</active>
+      <description>SPD/MACH LABEL</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_SPEED_MODE)" UUID="0" />
+        <test type="Float" value="-1" />
+        <modifiers>
+          <transformation active="True" expression="$-1" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="22" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="c41a732e-f9da-4f45-bc34-367b79c03ed1">
+      <active>true</active>
+      <description>HDG</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_FCU_HEADING)" UUID="f9fd0ffc-5343-4427-9399-21d308a99703" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="if(#=1, '---', $)" />
+          <padding active="True" direction="Left" length="3" character="0" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="19" value="$" />
+        <preconditions />
+        <configrefs>
+          <configref active="True" ref="0b4cfecd-ead9-4d96-94c6-adbad24f1605" placeholder="#" testvalue="1" />
+        </configrefs>
+      </settings>
+    </config>
+    <config guid="0b4cfecd-ead9-4d96-94c6-adbad24f1605">
+      <active>true</active>
+      <description>HDG DASHES</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:B_FCU_HEADING_DASHED)" UUID="0" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="964e2b28-50ce-46a1-aa19-62cbd1d3a4b0">
+      <active>true</active>
+      <description>HDG DOT</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_HEADING_MANAGED)" UUID="28029cad-8379-419c-ba1f-589cada617fa" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="11" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="a36e07dd-8ce2-4382-8bf1-bcb722bac0c5">
+      <active>true</active>
+      <description>HDG/VS TRK/FPA</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_HEADING_VS_MODE)" UUID="-" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="$-1" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="13" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="f1c2f225-8f50-40d3-a842-19809c2455c1">
+      <active>true</active>
+      <description>ALT</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_FCU_ALTITUDE)" UUID="d2cdad8d-8c2e-4620-ba30-6f2c35d326de" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <padding active="True" direction="Left" length="5" character="0" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="20" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="6dbfae93-a3ae-412c-8c91-8283c72c312a">
+      <active>true</active>
+      <description>ALT DOT</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_ALTITUDE_MANAGED)" UUID="bca70365-cd7c-4408-ad8e-4d7c5f578166" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="12" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="16bfb36a-a310-4029-886d-d049badb7cb8">
+      <active>true</active>
+      <description>VS HELPER</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_FCU_VS)" UUID="aa0d539d-855c-4473-a338-4212c7b3734a" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="'$'" />
+        </modifiers>
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="72813ded-7551-4727-901d-22ec46d256a0">
+      <active>true</active>
+      <description>VS OUTPUT</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_FCU_VS)" UUID="aa0d539d-855c-4473-a338-4212c7b3734a" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="Abs($/100)" />
+          <comparison active="True" value="0" operand="=" ifValue="00oo" elseValue="$oo" />
+          <padding active="True" direction="Left" length="4" character="0" />
+          <transformation active="True" expression="if(#&lt;0, '-$', '+$')" />
+        </modifiers>
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs>
+          <configref active="True" ref="16bfb36a-a310-4029-886d-d049badb7cb8" placeholder="#" testvalue="1" />
+        </configrefs>
+      </settings>
+    </config>
+    <config guid="c23ba13d-a813-466d-83bd-b8ff1f068c5a">
+      <active>true</active>
+      <description>FPA HELPER</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_FCU_VS)" UUID="aa0d539d-855c-4473-a338-4212c7b3734a" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="$/1000" />
+        </modifiers>
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="430204f0-ff72-48be-9e3c-33513bbafff4">
+      <active>true</active>
+      <description>FPA OUTPUT</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_FCU_VS)" UUID="aa0d539d-855c-4473-a338-4212c7b3734a" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="$/1000" />
+          <transformation active="True" expression="Round(Abs($), 1)" />
+          <transformation active="True" expression="if(Round($,1) - Round($,0) = 0, '$.0   0', '$   0')" />
+          <transformation active="True" expression="if(#&lt;0, '-$', '+$')" />
+          <padding active="True" direction="Right" length="6" character=" " />
+        </modifiers>
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs>
+          <configref active="True" ref="c23ba13d-a813-466d-83bd-b8ff1f068c5a" placeholder="#" testvalue="1" />
+        </configrefs>
+      </settings>
+    </config>
+    <config guid="6e144e29-e107-41e3-af41-ab557cfecee5">
+      <active>true</active>
+      <description>VS/FPA OUTPUT</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_HEADING_VS_MODE)" UUID="0" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <comparison active="False" value="0" operand="=" ifValue="'#'" elseValue="'!'" />
+          <transformation active="True" expression="if(?=1, '-----', if($=0, '#', '!'))" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="21" value="$" />
+        <preconditions />
+        <configrefs>
+          <configref active="True" ref="430204f0-ff72-48be-9e3c-33513bbafff4" placeholder="#" testvalue="1" />
+          <configref active="True" ref="72813ded-7551-4727-901d-22ec46d256a0" placeholder="!" testvalue="1" />
+          <configref active="True" ref="980ef639-80df-4fca-a066-25498555dda5" placeholder="?" testvalue="1" />
+        </configrefs>
+      </settings>
+    </config>
+    <config guid="980ef639-80df-4fca-a066-25498555dda5">
+      <active>true</active>
+      <description>VS DASHES</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:B_FCU_VERTICALSPEED_DASHED)" UUID="0" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="d2ae8663-e548-450d-94f9-5d0dc18d3e61">
+      <active>false</active>
+      <description>-</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <comparison active="True" value="" operand="=" ifValue="1" elseValue="0" />
+        </modifiers>
+        <display type="" serial="-" trigger="change" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="bbabe107-23c8-458a-86a2-6a295aa73f59">
+      <active>false</active>
+      <description>EFIS L CONFIG</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <comparison active="True" value="" operand="=" ifValue="1" elseValue="0" />
+        </modifiers>
+        <display type="" serial="-" trigger="change" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="4be04554-95e4-42c7-8bdf-a2b71bb89823">
+      <active>true</active>
+      <description>EFIS L inHg</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_FCU_EFIS1_BARO_INCH)" UUID="b192b3b7-e6ee-444a-8349-bd9fa0c074f6" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="Round($, 2)" />
+        </modifiers>
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="70993333-77ff-4afb-b4c0-4760ab112ba3">
+      <active>true</active>
+      <description>EFIS L hPa</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_FCU_EFIS1_BARO_HPA)" UUID="b192b3b7-e6ee-444a-8349-bd9fa0c074f6" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="Round($, 0)" />
+        </modifiers>
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="877b36f5-fedc-4607-b284-b68e349926ec">
+      <active>true</active>
+      <description>EFIS L STD</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_EFIS1_QNH)" UUID="0468d4e6-7488-4c67-a41a-23ede3e89391" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="13379caf-2018-4f23-a1c8-0c0dc75316ba">
+      <active>true</active>
+      <description>EFIS L MODE</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:S_FCU_EFIS1_BARO_MODE)" UUID="b192b3b7-e6ee-444a-8349-bd9fa0c074f6" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="1c384033-19a9-49d6-ad2d-b60ee61fe5c2">
+      <active>true</active>
+      <description>EFIS L QNH</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_EFIS1_QNH)" UUID="0468d4e6-7488-4c67-a41a-23ede3e89391" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS L" messageType="3" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="b6511dcf-1d8d-4431-8b5c-52897334a75b">
+      <active>true</active>
+      <description>EFIS L QFE</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_EFIS1_QFE)" UUID="-" />
+        <test type="String" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="72290261-e478-409a-a3fa-8648c30776e4">
+      <active>true</active>
+      <description>EFIS L OUTPUT</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="if(?=0, 'Std ', if(@=1, !, #))" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS L" messageType="5" value="$" />
+        <preconditions />
+        <configrefs>
+          <configref active="True" ref="4be04554-95e4-42c7-8bdf-a2b71bb89823" placeholder="#" testvalue="1" />
+          <configref active="True" ref="70993333-77ff-4afb-b4c0-4760ab112ba3" placeholder="!" testvalue="1" />
+          <configref active="True" ref="877b36f5-fedc-4607-b284-b68e349926ec" placeholder="?" testvalue="1" />
+          <configref active="True" ref="13379caf-2018-4f23-a1c8-0c0dc75316ba" placeholder="@" testvalue="1" />
+        </configrefs>
+      </settings>
+    </config>
+    <config guid="65265b30-007f-45d4-ae97-fada5b70709e">
+      <active>false</active>
+      <description>-</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <comparison active="True" value="" operand="=" ifValue="1" elseValue="0" />
+        </modifiers>
+        <display type="" serial="-" trigger="change" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="54f46104-80c3-46f7-a164-33c6d044e5e9">
+      <active>false</active>
+      <description>EFIS R CONFIG</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <comparison active="True" value="" operand="=" ifValue="1" elseValue="0" />
+        </modifiers>
+        <display type="" serial="-" trigger="change" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="8afcb990-dd40-4f72-b331-8ff8328e3e24">
+      <active>true</active>
+      <description>EFIS R inHg</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_FCU_EFIS2_BARO_INCH)" UUID="b192b3b7-e6ee-444a-8349-bd9fa0c074f6" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="Round($, 2)" />
+        </modifiers>
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="ef130492-6348-4671-97e0-b31678fa8648">
+      <active>true</active>
+      <description>EFIS R hPa</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_FCU_EFIS2_BARO_HPA)" UUID="b192b3b7-e6ee-444a-8349-bd9fa0c074f6" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="Round($, 0)" />
+        </modifiers>
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="94bb40ed-a955-4596-9f0a-9a6cd93b9fdc">
+      <active>true</active>
+      <description>EFIS R STD</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_EFIS2_QNH)" UUID="0468d4e6-7488-4c67-a41a-23ede3e89391" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="7f9fe683-b793-4f69-a168-01901b662e1d">
+      <active>true</active>
+      <description>EFIS R MODE</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:S_FCU_EFIS2_BARO_MODE)" UUID="b192b3b7-e6ee-444a-8349-bd9fa0c074f6" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="b2d2dbc2-a9c2-4ee3-8c55-523817c64b67">
+      <active>true</active>
+      <description>EFIS R QNH</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_EFIS2_QNH)" UUID="0468d4e6-7488-4c67-a41a-23ede3e89391" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS R" messageType="3" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="b4f68c38-bc1b-463d-a814-1892686b0340">
+      <active>true</active>
+      <description>EFIS R QFE</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_EFIS2_QFE)" UUID="0" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="fd6a9f1c-04ad-4570-a85f-90abd69fda3c">
+      <active>true</active>
+      <description>EFIS R OUTPUT</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="if(?=0, 'Std ', if(@=1, !, #))" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS R" messageType="5" value="$" />
+        <preconditions />
+        <configrefs>
+          <configref active="True" ref="8afcb990-dd40-4f72-b331-8ff8328e3e24" placeholder="#" testvalue="1" />
+          <configref active="True" ref="ef130492-6348-4671-97e0-b31678fa8648" placeholder="!" testvalue="1" />
+          <configref active="True" ref="94bb40ed-a955-4596-9f0a-9a6cd93b9fdc" placeholder="?" testvalue="1" />
+          <configref active="True" ref="7f9fe683-b793-4f69-a168-01901b662e1d" placeholder="@" testvalue="1" />
+        </configrefs>
+      </settings>
+    </config>
+    <config guid="7d62d0b5-04bb-4dbd-bcf1-48e4feba521e">
+      <active>false</active>
+      <description>-</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <comparison active="True" value="" operand="=" ifValue="1" elseValue="0" />
+        </modifiers>
+        <display type="" serial="-" trigger="change" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="4baca452-d284-4dc5-a4e8-45e5f697097c">
+      <active>true</active>
+      <description>BAT 1</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_ELEC_VOLT_BAT_1)" UUID="0" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="$*10" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Overhead/ SN-FF7-AF3" trigger="normal" customType="" customName="BAT 1" messageType="3" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="36ae365e-c349-4402-9c53-1cdf441f4a4a">
+      <active>true</active>
+      <description>BAT 2</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_ELEC_VOLT_BAT_2)" UUID="0" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="$*10" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Overhead/ SN-FF7-AF3" trigger="normal" customType="" customName="BAT 2" messageType="3" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="5e806ad2-777b-4b4f-9c30-e6cbc476b80c">
+      <active>true</active>
+      <description>RMP 3 ACTIVE</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_PED_RMP3_ACTIVE)" UUID="af4bdeb7-fb66-45a9-9566-4792da66d448" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="CustomDevice" serial="Kav Overhead/ SN-FF7-AF3" trigger="normal" customType="" customName="ACTIVE" messageType="2" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="b8f31b3c-aeb2-41c2-a798-328ebca841bb">
+      <active>true</active>
+      <description>RMP 3 STBY</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_PED_RMP3_STDBY)" UUID="af4bdeb7-fb66-45a9-9566-4792da66d448" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <comparison active="True" value="118000" operand="=" ifValue="0" elseValue="$" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Overhead/ SN-FF7-AF3" trigger="normal" customType="" customName="STBY-CRS" messageType="2" value="$" />
+        <preconditions />
+        <configrefs>
+          <configref active="True" ref="5e806ad2-777b-4b4f-9c30-e6cbc476b80c" placeholder="#" testvalue="1" />
+        </configrefs>
+      </settings>
+    </config>
+    <config guid="53478d38-0e0d-4e5f-ac6c-b9ef30c45181">
+      <active>false</active>
+      <description>-</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <comparison active="True" value="" operand="=" ifValue="1" elseValue="0" />
+        </modifiers>
+        <display type="" serial="-" trigger="change" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="fe1f3fbe-01b2-440a-b06d-4d6473326279">
+      <active>true</active>
+      <description>RMP 1 ACTIVE</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_PED_RMP1_ACTIVE)" UUID="-" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="CustomDevice" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" customType="" customName="RMP L ACTIVE" messageType="2" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="32975d9f-e50f-4300-85a4-225b81d773ca">
+      <active>true</active>
+      <description>RMP 1 STBY</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_PED_RMP1_STDBY)" UUID="0" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="CustomDevice" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" customType="" customName="RMP L STBY-CRS" messageType="2" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="a11fdc65-f6a7-49b4-897b-d15e7929fed5">
+      <active>true</active>
+      <description>RMP 2 ACTIVE</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_PED_RMP2_ACTIVE)" UUID="0" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="CustomDevice" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" customType="" customName="RMP R ACTIVE" messageType="2" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="d2a751e9-f38a-435b-841d-02f57e6016d2">
+      <active>true</active>
+      <description>RMP 2 STBY</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_PED_RMP2_STDBY)" UUID="0" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="CustomDevice" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" customType="" customName="RMP R STBY-CRS" messageType="2" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="9624a723-ceb5-4a49-9f73-d499f1ed7ee8">
+      <active>true</active>
+      <description>TCAS</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_FREQ_XPDR_SELECTED)" UUID="0" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="False" expression="Floor($*Pow(10, #) / 10000)" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" customType="" customName="TCAS" messageType="3" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="ebc0a586-a2da-4666-ae93-e39b5871f896">
+      <active>true</active>
+      <description>RUDDER TRIM</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_FC_RUDDER_TRIM_DECIMAL)" UUID="0" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="CustomDevice" serial="Kav Mega Pedesta/ SN-346-31C" trigger="normal" customType="" customName="RUDDER TRIM" messageType="6" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="6020407a-0b66-4ed8-aea6-83c8bcdb4de1">
+      <active>false</active>
+      <description />
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.2.1.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <comparison active="True" value="" operand="=" ifValue="1" elseValue="0" />
+        </modifiers>
+        <display type="" serial="-" trigger="change" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+  </outputs>
+  <inputs />
+</MobiflightConnector>

--- a/KAV_Simulation/Community/profiles/msfs2020/Fenix A320/FENIX - KAV FIRMWARE V2-0-0-392 (NO QUARTZ).mcc
+++ b/KAV_Simulation/Community/profiles/msfs2020/Fenix A320/FENIX - KAV FIRMWARE V2-0-0-392 (NO QUARTZ).mcc
@@ -1,0 +1,508 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<MobiflightConnector>
+  <outputs>
+    <config guid="5a1bf488-659d-4c25-98bf-ffd43dd20a94">
+      <active>false</active>
+      <description>FCU CONFIG</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <comparison active="True" value="" operand="=" ifValue="1" elseValue="0" />
+        </modifiers>
+        <display type="" serial="-" trigger="change" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="56756680-25cd-4f2b-9ca1-2065fd60574a">
+      <active>true</active>
+      <description>SPD</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_FCU_SPEED)" UUID="ee3f0a8c-fb85-430b-8659-5597c6b66a4f" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="if(#=1, '---', if($&lt;100, '0.$', $))" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="18" value="$" />
+        <preconditions />
+        <configrefs>
+          <configref active="True" ref="7a059f7e-49f0-44e5-b136-eac092e40b71" placeholder="#" testvalue="1" />
+        </configrefs>
+      </settings>
+    </config>
+    <config guid="7a059f7e-49f0-44e5-b136-eac092e40b71">
+      <active>true</active>
+      <description>SPD DASHES</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:B_FCU_SPEED_DASHED)" UUID="0" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="a08b884c-9512-4967-86bb-79104ebf3139">
+      <active>true</active>
+      <description>SPD DOT</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_SPEED_MANAGED)" UUID="28029cad-8379-419c-ba1f-589cada617fa" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="10" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="26917f9f-f6ab-40d7-b2f8-e0591e555713">
+      <active>true</active>
+      <description>SPD/MACH LABEL</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_SPEED_MODE)" UUID="0" />
+        <test type="Float" value="-1" />
+        <modifiers>
+          <transformation active="True" expression="$-1" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="22" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="c41a732e-f9da-4f45-bc34-367b79c03ed1">
+      <active>true</active>
+      <description>HDG</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_FCU_HEADING)" UUID="f9fd0ffc-5343-4427-9399-21d308a99703" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="if(#=1, '---', $)" />
+          <padding active="True" direction="Left" length="3" character="0" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="19" value="$" />
+        <preconditions />
+        <configrefs>
+          <configref active="True" ref="0b4cfecd-ead9-4d96-94c6-adbad24f1605" placeholder="#" testvalue="1" />
+        </configrefs>
+      </settings>
+    </config>
+    <config guid="0b4cfecd-ead9-4d96-94c6-adbad24f1605">
+      <active>true</active>
+      <description>HDG DASHES</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:B_FCU_HEADING_DASHED)" UUID="0" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="964e2b28-50ce-46a1-aa19-62cbd1d3a4b0">
+      <active>true</active>
+      <description>HDG DOT</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_HEADING_MANAGED)" UUID="28029cad-8379-419c-ba1f-589cada617fa" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="11" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="a36e07dd-8ce2-4382-8bf1-bcb722bac0c5">
+      <active>true</active>
+      <description>HDG/VS TRK/FPA</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_HEADING_VS_MODE)" UUID="-" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="$-1" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="13" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="f1c2f225-8f50-40d3-a842-19809c2455c1">
+      <active>true</active>
+      <description>ALT</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_FCU_ALTITUDE)" UUID="d2cdad8d-8c2e-4620-ba30-6f2c35d326de" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <padding active="True" direction="Left" length="5" character="0" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="20" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="6dbfae93-a3ae-412c-8c91-8283c72c312a">
+      <active>true</active>
+      <description>ALT DOT</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_ALTITUDE_MANAGED)" UUID="bca70365-cd7c-4408-ad8e-4d7c5f578166" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="12" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="16bfb36a-a310-4029-886d-d049badb7cb8">
+      <active>true</active>
+      <description>VS HELPER</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_FCU_VS)" UUID="aa0d539d-855c-4473-a338-4212c7b3734a" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="'$'" />
+        </modifiers>
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="72813ded-7551-4727-901d-22ec46d256a0">
+      <active>true</active>
+      <description>VS OUTPUT</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_FCU_VS)" UUID="aa0d539d-855c-4473-a338-4212c7b3734a" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="Abs($/100)" />
+          <comparison active="True" value="0" operand="=" ifValue="00oo" elseValue="$oo" />
+          <padding active="True" direction="Left" length="4" character="0" />
+          <transformation active="True" expression="if(#&lt;0, '-$', '+$')" />
+        </modifiers>
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs>
+          <configref active="True" ref="16bfb36a-a310-4029-886d-d049badb7cb8" placeholder="#" testvalue="1" />
+        </configrefs>
+      </settings>
+    </config>
+    <config guid="c23ba13d-a813-466d-83bd-b8ff1f068c5a">
+      <active>true</active>
+      <description>FPA HELPER</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_FCU_VS)" UUID="aa0d539d-855c-4473-a338-4212c7b3734a" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="$/1000" />
+        </modifiers>
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="430204f0-ff72-48be-9e3c-33513bbafff4">
+      <active>true</active>
+      <description>FPA OUTPUT</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_FCU_VS)" UUID="aa0d539d-855c-4473-a338-4212c7b3734a" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="$/1000" />
+          <transformation active="True" expression="Round(Abs($), 1)" />
+          <transformation active="True" expression="if(Round($,1) - Round($,0) = 0, '$.0   0', '$   0')" />
+          <transformation active="True" expression="if(#&lt;0, '-$', '+$')" />
+          <padding active="True" direction="Right" length="6" character=" " />
+        </modifiers>
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs>
+          <configref active="True" ref="c23ba13d-a813-466d-83bd-b8ff1f068c5a" placeholder="#" testvalue="1" />
+        </configrefs>
+      </settings>
+    </config>
+    <config guid="6e144e29-e107-41e3-af41-ab557cfecee5">
+      <active>true</active>
+      <description>VS/FPA OUTPUT</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_HEADING_VS_MODE)" UUID="0" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <comparison active="False" value="0" operand="=" ifValue="'#'" elseValue="'!'" />
+          <transformation active="True" expression="if(?=1, '-----', if($=0, '#', '!'))" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="FCU LCD" messageType="21" value="$" />
+        <preconditions />
+        <configrefs>
+          <configref active="True" ref="430204f0-ff72-48be-9e3c-33513bbafff4" placeholder="#" testvalue="1" />
+          <configref active="True" ref="72813ded-7551-4727-901d-22ec46d256a0" placeholder="!" testvalue="1" />
+          <configref active="True" ref="980ef639-80df-4fca-a066-25498555dda5" placeholder="?" testvalue="1" />
+        </configrefs>
+      </settings>
+    </config>
+    <config guid="980ef639-80df-4fca-a066-25498555dda5">
+      <active>true</active>
+      <description>VS DASHES</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:B_FCU_VERTICALSPEED_DASHED)" UUID="0" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="d2ae8663-e548-450d-94f9-5d0dc18d3e61">
+      <active>false</active>
+      <description>-</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <comparison active="True" value="" operand="=" ifValue="1" elseValue="0" />
+        </modifiers>
+        <display type="" serial="-" trigger="change" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="bbabe107-23c8-458a-86a2-6a295aa73f59">
+      <active>true</active>
+      <description>EFIS L CONFIG</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <comparison active="True" value="" operand="=" ifValue="1" elseValue="0" />
+        </modifiers>
+        <display type="" serial="-" trigger="change" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="4be04554-95e4-42c7-8bdf-a2b71bb89823">
+      <active>true</active>
+      <description>EFIS L inHg</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_FCU_EFIS1_BARO_INCH)" UUID="b192b3b7-e6ee-444a-8349-bd9fa0c074f6" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="Round($, 2)" />
+        </modifiers>
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="70993333-77ff-4afb-b4c0-4760ab112ba3">
+      <active>true</active>
+      <description>EFIS L hPa</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_FCU_EFIS1_BARO_HPA)" UUID="b192b3b7-e6ee-444a-8349-bd9fa0c074f6" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="Round($, 0)" />
+        </modifiers>
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="877b36f5-fedc-4607-b284-b68e349926ec">
+      <active>true</active>
+      <description>EFIS L STD</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_EFIS1_QNH)" UUID="0468d4e6-7488-4c67-a41a-23ede3e89391" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="13379caf-2018-4f23-a1c8-0c0dc75316ba">
+      <active>true</active>
+      <description>EFIS L MODE</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:S_FCU_EFIS1_BARO_MODE)" UUID="b192b3b7-e6ee-444a-8349-bd9fa0c074f6" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="1c384033-19a9-49d6-ad2d-b60ee61fe5c2">
+      <active>true</active>
+      <description>EFIS L QNH</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_EFIS1_QNH)" UUID="0468d4e6-7488-4c67-a41a-23ede3e89391" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS L" messageType="3" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="b6511dcf-1d8d-4431-8b5c-52897334a75b">
+      <active>true</active>
+      <description>EFIS L QFE</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_EFIS1_QFE)" UUID="-" />
+        <test type="String" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="72290261-e478-409a-a3fa-8648c30776e4">
+      <active>true</active>
+      <description>EFIS L OUTPUT</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="" UUID="-" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="if(?=0, 'Std ', if(@=1, !, #))" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS L" messageType="5" value="$" />
+        <preconditions />
+        <configrefs>
+          <configref active="True" ref="4be04554-95e4-42c7-8bdf-a2b71bb89823" placeholder="#" testvalue="1" />
+          <configref active="True" ref="70993333-77ff-4afb-b4c0-4760ab112ba3" placeholder="!" testvalue="1" />
+          <configref active="True" ref="877b36f5-fedc-4607-b284-b68e349926ec" placeholder="?" testvalue="1" />
+          <configref active="True" ref="13379caf-2018-4f23-a1c8-0c0dc75316ba" placeholder="@" testvalue="1" />
+        </configrefs>
+      </settings>
+    </config>
+    <config guid="65265b30-007f-45d4-ae97-fada5b70709e">
+      <active>false</active>
+      <description>-</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <comparison active="True" value="" operand="=" ifValue="1" elseValue="0" />
+        </modifiers>
+        <display type="" serial="-" trigger="change" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="54f46104-80c3-46f7-a164-33c6d044e5e9">
+      <active>false</active>
+      <description>EFIS R CONFIG</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <comparison active="True" value="" operand="=" ifValue="1" elseValue="0" />
+        </modifiers>
+        <display type="" serial="-" trigger="change" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="8afcb990-dd40-4f72-b331-8ff8328e3e24">
+      <active>true</active>
+      <description>EFIS R inHg</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_FCU_EFIS2_BARO_INCH)" UUID="b192b3b7-e6ee-444a-8349-bd9fa0c074f6" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="Round($, 2)" />
+        </modifiers>
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="ef130492-6348-4671-97e0-b31678fa8648">
+      <active>true</active>
+      <description>EFIS R hPa</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:N_FCU_EFIS2_BARO_HPA)" UUID="b192b3b7-e6ee-444a-8349-bd9fa0c074f6" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="Round($, 0)" />
+        </modifiers>
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="94bb40ed-a955-4596-9f0a-9a6cd93b9fdc">
+      <active>true</active>
+      <description>EFIS R STD</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_EFIS2_QNH)" UUID="0468d4e6-7488-4c67-a41a-23ede3e89391" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="7f9fe683-b793-4f69-a168-01901b662e1d">
+      <active>true</active>
+      <description>EFIS R MODE</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:S_FCU_EFIS2_BARO_MODE)" UUID="b192b3b7-e6ee-444a-8349-bd9fa0c074f6" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="b2d2dbc2-a9c2-4ee3-8c55-523817c64b67">
+      <active>true</active>
+      <description>EFIS R QNH</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_EFIS2_QNH)" UUID="0468d4e6-7488-4c67-a41a-23ede3e89391" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS R" messageType="3" value="$" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="b4f68c38-bc1b-463d-a814-1892686b0340">
+      <active>true</active>
+      <description>EFIS R QFE</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:I_FCU_EFIS2_QFE)" UUID="0" />
+        <test type="Float" value="1" />
+        <modifiers />
+        <display type="-" serial="-" trigger="normal" pin="" pinBrightness="255" />
+        <preconditions />
+        <configrefs />
+      </settings>
+    </config>
+    <config guid="fd6a9f1c-04ad-4570-a85f-90abd69fda3c">
+      <active>true</active>
+      <description>EFIS R OUTPUT</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=10.1.4.2, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="" UUID="-" />
+        <test type="Float" value="1" />
+        <modifiers>
+          <transformation active="True" expression="if(?=0, 'Std ', if(@=1, !, #))" />
+        </modifiers>
+        <display type="CustomDevice" serial="Kav Glareshield/ SN-E98-277" trigger="normal" customType="" customName="EFIS R" messageType="5" value="$" />
+        <preconditions />
+        <configrefs>
+          <configref active="True" ref="8afcb990-dd40-4f72-b331-8ff8328e3e24" placeholder="#" testvalue="1" />
+          <configref active="True" ref="ef130492-6348-4671-97e0-b31678fa8648" placeholder="!" testvalue="1" />
+          <configref active="True" ref="94bb40ed-a955-4596-9f0a-9a6cd93b9fdc" placeholder="?" testvalue="1" />
+          <configref active="True" ref="7f9fe683-b793-4f69-a168-01901b662e1d" placeholder="@" testvalue="1" />
+        </configrefs>
+      </settings>
+    </config>
+    <config guid="7d62d0b5-04bb-4dbd-bcf1-48e4feba521e">
+      <active>false</active>
+      <converter>Boolean</converter>
+      <comparison>=</comparison>
+      <description>-</description>
+      <fsuipcSize>1</fsuipcSize>
+      <trigger>change</trigger>
+      <arcazeSerial>-</arcazeSerial>
+    </config>
+  </outputs>
+  <inputs />
+</MobiflightConnector>

--- a/KAV_Simulation/Community/profiles/msfs2020/Fenix A320/README.md
+++ b/KAV_Simulation/Community/profiles/msfs2020/Fenix A320/README.md
@@ -1,0 +1,8 @@
+# Fenix A320 Config Files
+
+There are 2 variants of the Fenix here:
+
+1) Fenix A320 config file for Fenix v2.0.0.378 - It still requires the Fenix Quartz plugin.
+2) Fenix A320 config file for Fenix v2.0.0.392 - Uses the new native Fenix LVARS, and does __NOT__ require the Quartz plugin.
+
+There is a full cockpit profile for the v2.0.0.392 variant only.

--- a/KAV_Simulation/KAV_A3XX_BATTERY_LCD.cpp
+++ b/KAV_Simulation/KAV_A3XX_BATTERY_LCD.cpp
@@ -188,6 +188,16 @@ void KAV_A3XX_BATTERY_LCD::displayDigit(uint8_t address, uint8_t digit)
     refreshLCD(address);
 }
 
+void KAV_A3XX_BATTERY_LCD::setAnnunciatorTest(bool enabled)
+{
+    if (enabled) {
+        for (uint8_t i = 0; i < ht_battery.MAX_ADDR; i++)
+            ht_battery.write(i, 0xFF);
+    } else {
+        clearLCD();
+    }
+}
+
 /**
  * Handle MobiFlight Commands
  * This function shouldn't be called be a user, it should only be called by the
@@ -220,4 +230,6 @@ void KAV_A3XX_BATTERY_LCD::set(int16_t messageID, char *setPoint)
         setValueInt((uint16_t)data);
     else if (messageID == 3)
         showBattValueInt((uint16_t)data);
+    else if(messageID == 4)
+        setAnnunciatorTest((bool)data);
 }

--- a/KAV_Simulation/KAV_A3XX_BATTERY_LCD.h
+++ b/KAV_Simulation/KAV_A3XX_BATTERY_LCD.h
@@ -48,4 +48,7 @@ public:
 
   // Show BATTERY Value function
   void showBattValueInt(uint16_t value);
+
+  // Annunciator Test Function
+  void setAnnunciatorTest(bool enabled);
 };

--- a/KAV_Simulation/KAV_A3XX_EFIS_LCD.cpp
+++ b/KAV_Simulation/KAV_A3XX_EFIS_LCD.cpp
@@ -190,6 +190,16 @@ void KAV_A3XX_EFIS_LCD::showQFEQNHValue(char* value)
     refreshLCD(DIGIT_ONE, 4);
 }
 
+void KAV_A3XX_EFIS_LCD::setAnnunciatorTest(bool enabled)
+{
+    if (enabled) {
+        for (uint8_t i = 0; i < ht_efis.MAX_ADDR; i++)
+            ht_efis.write(i, 0xFF);
+    } else {
+        clearLCD();
+    }
+}
+
 // Global Functions
 
 void KAV_A3XX_EFIS_LCD::set(int16_t messageID, char *setPoint)
@@ -220,4 +230,6 @@ void KAV_A3XX_EFIS_LCD::set(int16_t messageID, char *setPoint)
         setQFElabel((bool)data);
     else if (messageID == 5)
         showQFEQNHValue(setPoint);
+    else if (messageID == 6)
+        setAnnunciatorTest((bool)data);
 }

--- a/KAV_Simulation/KAV_A3XX_EFIS_LCD.h
+++ b/KAV_Simulation/KAV_A3XX_EFIS_LCD.h
@@ -58,4 +58,7 @@ public:
     void showQFEQNHValue(uint16_t value);
     void showQFEQNHValue(float value);
     void showQFEQNHValue(char* value);
+
+    // Annunciator Test Function
+    void setAnnunciatorTest(bool enabled);
 };

--- a/KAV_Simulation/KAV_A3XX_FCU_LCD.cpp
+++ b/KAV_Simulation/KAV_A3XX_FCU_LCD.cpp
@@ -424,6 +424,16 @@ void KAV_A3XX_FCU_LCD::clearOrReset(bool enabled)
         clearLCD();
 }
 
+void KAV_A3XX_FCU_LCD::setAnnunciatorTest(bool enabled)
+{
+    if (enabled) {
+        for (uint8_t i = 0; i < ht.MAX_ADDR; i++)
+            ht.write(i, 0xFF);
+    } else {
+        clearLCD();
+    }
+}
+
 void KAV_A3XX_FCU_LCD::set(int16_t messageID, char *setPoint)
 {
     int32_t data = strtol(setPoint, NULL, 10);
@@ -486,4 +496,6 @@ void KAV_A3XX_FCU_LCD::set(int16_t messageID, char *setPoint)
         showVerticalFPAValue(setPoint);
     else if (messageID == 22)
         toggleSpeedMachMode((bool)data);
+    else if (messageID == 23)
+        setAnnunciatorTest((bool)data);
 }

--- a/KAV_Simulation/KAV_A3XX_FCU_LCD.h
+++ b/KAV_Simulation/KAV_A3XX_FCU_LCD.h
@@ -95,4 +95,5 @@ public:
     void setHeadingMode();
     void setTrackMode();
     void clearOrReset(bool enabled);
+    void setAnnunciatorTest(bool enabled);
 };

--- a/KAV_Simulation/KAV_A3XX_RAD_TCAS_LCD.cpp
+++ b/KAV_Simulation/KAV_A3XX_RAD_TCAS_LCD.cpp
@@ -284,4 +284,6 @@ void KAV_A3XX_RAD_TCAS_LCD::set(int16_t messageID, char *setPoint)
         showRadio((uint32_t)data);
     else if (messageID == 3)
         showTcas((uint16_t)data);
+    else if (messageID == 4)
+        showTest((bool)data);
 }

--- a/KAV_Simulation/KAV_A3XX_RAD_TCAS_LCD.h
+++ b/KAV_Simulation/KAV_A3XX_RAD_TCAS_LCD.h
@@ -46,7 +46,7 @@ public:
   void setRadioValue(uint32_t value);
   void setTcasValue(uint16_t value);
 
-  // Show Rudder Value function
+  // Show Value function
   void showRadio(uint32_t value);
   void showTcas(uint16_t value);
   void showTest(bool enabled);

--- a/KAV_Simulation/KAV_A3XX_RUDDER_LCD.cpp
+++ b/KAV_Simulation/KAV_A3XX_RUDDER_LCD.cpp
@@ -15,14 +15,14 @@
  */
 void KAV_A3XX_RUDDER_LCD::begin()
 {
-    ht_rad_tcas.begin();
-    ht_rad_tcas.sendCommand(HT1621::RC256K);
-    ht_rad_tcas.sendCommand(HT1621::BIAS_THIRD_4_COM);
-    ht_rad_tcas.sendCommand(HT1621::SYS_EN);
-    ht_rad_tcas.sendCommand(HT1621::LCD_ON);
+    ht_rudder.begin();
+    ht_rudder.sendCommand(HT1621::RC256K);
+    ht_rudder.sendCommand(HT1621::BIAS_THIRD_4_COM);
+    ht_rudder.sendCommand(HT1621::SYS_EN);
+    ht_rudder.sendCommand(HT1621::LCD_ON);
     // This clears the LCD
-    for (uint8_t i = 0; i < ht_rad_tcas.MAX_ADDR; i++)
-        ht_rad_tcas.write(i, 0);
+    for (uint8_t i = 0; i < ht_rudder.MAX_ADDR; i++)
+        ht_rudder.write(i, 0);
 
     // Initialises the buffer to all 0's.
     memset(buffer, 0, BUFFER_SIZE_MAX);
@@ -63,7 +63,7 @@ void KAV_A3XX_RUDDER_LCD::detach()
  */
 void KAV_A3XX_RUDDER_LCD::refreshLCD(uint8_t address)
 {
-    ht_rad_tcas.write(address * 2, buffer[address], 8);
+    ht_rudder.write(address * 2, buffer[address], 8);
 }
 
 /**
@@ -72,14 +72,14 @@ void KAV_A3XX_RUDDER_LCD::refreshLCD(uint8_t address)
  */
 void KAV_A3XX_RUDDER_LCD::clearLCD()
 {
-    for (uint8_t i = 0; i < ht_rad_tcas.MAX_ADDR; i++)
-        ht_rad_tcas.write(i, 0);
+    for (uint8_t i = 0; i < ht_rudder.MAX_ADDR; i++)
+        ht_rudder.write(i, 0);
     memset(buffer, 0, BUFFER_SIZE_MAX);
 }
 
 void KAV_A3XX_RUDDER_LCD::clearDigit(uint8_t address)
 {
-    ht_rad_tcas.write(address * 2, 0);
+    ht_rudder.write(address * 2, 0);
     buffer[address] = 0;
 }
 
@@ -231,6 +231,16 @@ void KAV_A3XX_RUDDER_LCD::displayDigit(uint8_t address, uint8_t digit)
     refreshLCD(address);
 }
 
+void KAV_A3XX_RUDDER_LCD::setAnnunciatorTest(bool enabled)
+{
+    if (enabled) {
+        for (uint8_t i = 0; i < ht_rudder.MAX_ADDR; i++)
+            ht_rudder.write(i, 0xFF);
+    } else {
+        clearLCD();
+    }
+}
+
 /**
  * Handle MobiFlight Commands
  * This function shouldn't be called be a user, it should only be called by the
@@ -272,4 +282,6 @@ void KAV_A3XX_RUDDER_LCD::set(int16_t messageID, char *setPoint)
     else if (messageID == 6)
         // This one needs to keep it's sign, so using `int16_t`.
         showLandRValue((int16_t)data);
+    else if (messageID == 7)
+        setAnnunciatorTest((bool)data);
 }

--- a/KAV_Simulation/KAV_A3XX_RUDDER_LCD.h
+++ b/KAV_Simulation/KAV_A3XX_RUDDER_LCD.h
@@ -14,7 +14,7 @@
 class KAV_A3XX_RUDDER_LCD {
 private:
   // Fields
-  HT1621 ht_rad_tcas;
+  HT1621 ht_rudder;
   uint8_t buffer[BUFFER_SIZE_MAX];
   bool _initialised;
   byte _CS;
@@ -28,7 +28,7 @@ private:
 public:
   // Constructor
   // 'CLK' is sometimes referred to as 'RW'
-  KAV_A3XX_RUDDER_LCD(uint8_t CS, uint8_t CLK, uint8_t DATA) : ht_rad_tcas(CS, CLK, DATA) { };
+  KAV_A3XX_RUDDER_LCD(uint8_t CS, uint8_t CLK, uint8_t DATA) : ht_rudder(CS, CLK, DATA) { };
 
   void begin();
   void clearLCD();
@@ -49,4 +49,7 @@ public:
   void showLeftValueInt(uint16_t value);
   void showRightValueInt(uint16_t value);
   void showLandRValue(int16_t value);
+
+  // Set Annunciator Test
+  void setAnnunciatorTest(bool enabled);
 };


### PR DESCRIPTION
## Description of changes

Fixes #27 - This requested seperate control of the TRK/FPA labels so that an annuciator test could be implemented. We have instead created an independant annunciator test.

* This new firmware version (v2.5.5) has added new Fenix A320 profiles.
* We have also created 'Annunciator Test' functions for all display types. This will allow a boolean on or off to turn on all segments in the LCD for the annunciator test functions.
