### PR TITLE
Set FW version to 2.6.1

### DIFF
--- a/KAV_Simulation/Community/boards/kav_mega.board.json
+++ b/KAV_Simulation/Community/boards/kav_mega.board.json
@@ -37,7 +37,7 @@
     "DelayAfterFirmwareUpdate": 0,
     "FirmwareBaseName": "kav_mega",
     "FirmwareExtension": "hex",
-    "LatestFirmwareVersion": "2.5.5",
+    "LatestFirmwareVersion": "2.6.1",
     "FriendlyName": "Kav Mega",
     "MobiFlightType": "Kav Mega",
     "ResetFirmwareFile": "reset.arduino_mega_1_0_2.hex",

--- a/KAV_Simulation/Community/boards/kav_pico.board.json
+++ b/KAV_Simulation/Community/boards/kav_pico.board.json
@@ -20,7 +20,7 @@
     "FirmwareBaseName": "kav_raspberrypico",
     "FirmwareExtension": "uf2",
     "FriendlyName": "Kav RaspiPico",
-    "LatestFirmwareVersion": "2.5.5",
+    "LatestFirmwareVersion": "2.6.1",
     "MobiFlightType": "Kav RaspiPico",
     "ResetFirmwareFile": "reset.raspberry_pico_flash_nuke.uf2",
     "CustomDeviceTypes": [


### PR DESCRIPTION
## Description of changes

With firmware version 2.6.0 a couple of improvents were released. Unfortenutely the version number in the board.json files were not revised. So updating the boards with Mobiflight fails as the wrong FW file are referenced (still 2.5.5).
This PR sets the version in the board.json files to 2.6.1 which will be the next release version.
