### PR TITLE
Fix wrong pin order for rudder display

### DIFF
--- a/KAV_Simulation/Community/devices/kav_rudder.device.json
+++ b/KAV_Simulation/Community/devices/kav_rudder.device.json
@@ -10,8 +10,8 @@
     "Config": {
       "Pins": [
         "Data",
-        "CS",
-        "CLK"
+        "CLK",
+        "CS"
       ],
       "isI2C": false
     },

--- a/KAV_Simulation/Community/devices/kav_rudder.device.json
+++ b/KAV_Simulation/Community/devices/kav_rudder.device.json
@@ -5,7 +5,7 @@
       "Type": "KAV_RUDDER",
       "Author": "Jak Kav",
       "URL": "https://github.com/MobiFlight/MobiFlight-CustomDevices/tree/main/KAV_Simulation/EFIS_FCU",
-      "Version" : "1.0.1"
+      "Version" : "1.0.2"
     },
     "Config": {
       "Pins": [


### PR DESCRIPTION
## Description of changes

When starting PR #19 the order of pins didn't reflect the order of pins on the real display.
This was changed in PR #24 , but this change wasn't merged into PR #19 which was still open.
With merging PR #19 (which was month later than PR #24) the old pin order came in again.
But this pin order isn't anymore what the FW expects, so pin `CS` and `CLK` are in the wrong order.

This PR changes the pin order according PR #24 again which is the order the FW expects.

