### PR TITLE
Update github workflow 'upload artifact'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         run: pio run
 
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ZIP files
           path: ./_dist/*.zip


### PR DESCRIPTION
## Description of changes

Actual workflow uses a deprecated version of `actions/upload-artifact: v3`.
This PR changes it to the actual one to get the release process to work again.
