### PR TITLE
Prepare for next version 2.6.2

### DIFF
--- a/KAV_Simulation/Community/boards/kav_mega.board.json
+++ b/KAV_Simulation/Community/boards/kav_mega.board.json
@@ -37,7 +37,7 @@
     "DelayAfterFirmwareUpdate": 0,
     "FirmwareBaseName": "kav_mega",
     "FirmwareExtension": "hex",
-    "LatestFirmwareVersion": "2.6.1",
+    "LatestFirmwareVersion": "2.6.2",
     "FriendlyName": "Kav Mega",
     "MobiFlightType": "Kav Mega",
     "ResetFirmwareFile": "reset.arduino_mega_1_0_2.hex",

--- a/KAV_Simulation/Community/boards/kav_pico.board.json
+++ b/KAV_Simulation/Community/boards/kav_pico.board.json
@@ -20,7 +20,7 @@
     "FirmwareBaseName": "kav_raspberrypico",
     "FirmwareExtension": "uf2",
     "FriendlyName": "Kav RaspiPico",
-    "LatestFirmwareVersion": "2.6.1",
+    "LatestFirmwareVersion": "2.6.2",
     "MobiFlightType": "Kav RaspiPico",
     "ResetFirmwareFile": "reset.raspberry_pico_flash_nuke.uf2",
     "CustomDeviceTypes": [


### PR DESCRIPTION
## Description of changes

FW version in the board.json files are set to 2.6.2 which might be the next released version.
This is the formal requirement for a new release.
No other changes are included.
